### PR TITLE
Update indexed fields in Portal events

### DIFF
--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -85,10 +85,6 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
             abi.encodePacked(index_, refundAddress_)
         );
 
-        // TODO: NttManager will have an additional `TransferSent` event that includes
-        //       messageId (aka digest), but doesn't include an additional payload (index).
-        //       Profile the gas cost of calculating messageId here to determine
-        //       whether we should include it in our `MTokenSent` event or use NttManager's event.
         bytes32 messageId_ = TransceiverStructs.nttManagerMessageDigest(
             chainId,
             TransceiverStructs.NttManagerMessage(

--- a/src/interfaces/IHubPortal.sol
+++ b/src/interfaces/IHubPortal.sol
@@ -4,10 +4,6 @@ pragma solidity 0.8.26;
 
 import { IPortal } from "./IPortal.sol";
 
-// TODO: If the bridges will already emit events that contain the `messageId` and the `destinationChainId`, then we can
-//       longer need to index the `destinationChainId` and `bridge` in these, and can index the other data instead. This
-//       is because you can cross-reference the `messageId` with the other events form the bridge to index that info.
-
 /**
  * @title  HubPortal interface.
  * @author M^0 Labs
@@ -33,7 +29,7 @@ interface IHubPortal is IPortal {
      * @param  messageId          The unique identifier for the sent message.
      * @param  index              The the M token index.
      */
-    event MTokenIndexSent(uint16 indexed destinationChainId, bytes32 indexed messageId, uint128 index);
+    event MTokenIndexSent(uint16 indexed destinationChainId, bytes32 messageId, uint128 index);
 
     /**
      * @notice Emitted when the Registrar key is sent to a destination chain.
@@ -42,7 +38,7 @@ interface IHubPortal is IPortal {
      * @param  key                The key that was sent.
      * @param  value              The value that was sent.
      */
-    event RegistrarKeySent(uint16 indexed destinationChainId, bytes32 indexed messageId, bytes32 key, bytes32 value);
+    event RegistrarKeySent(uint16 indexed destinationChainId, bytes32 messageId, bytes32 indexed key, bytes32 value);
 
     /**
      * @notice Emitted when the Registrar list status for an account is sent to a destination chain.
@@ -54,9 +50,9 @@ interface IHubPortal is IPortal {
      */
     event RegistrarListStatusSent(
         uint16 indexed destinationChainId,
-        bytes32 indexed messageId,
-        bytes32 listName,
-        address account,
+        bytes32 messageId,
+        bytes32 indexed listName,
+        address indexed account,
         bool status
     );
 

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -20,9 +20,9 @@ interface IPortal {
      */
     event MTokenSent(
         uint16 indexed destinationChainId,
-        bytes32 indexed messageId,
-        address sender,
-        bytes32 recipient,
+        bytes32 messageId,
+        address indexed sender,
+        bytes32 indexed recipient,
         uint256 amount,
         uint128 index
     );
@@ -37,9 +37,9 @@ interface IPortal {
      * @param  index         The the M token index.
      */
     event MTokenReceived(
-        uint16 sourceChainId,
-        bytes32 indexed messageId,
-        bytes32 sender,
+        uint16 indexed sourceChainId,
+        bytes32 messageId,
+        bytes32 indexed sender,
         address indexed recipient,
         uint256 amount,
         uint128 index


### PR DESCRIPTION
### Proposed changes

- index `sender`, `recipient` and `destinationChainId` in `MTokenSent` event.
- index `sender`, `recipient` and `sourceChainId` in `MTokenReceive` event
- index `listName`, `account` and  `destinationChainId` in `RegistrarListStatusSent` event
- remove TODO comments that no longer apply

### Motivation

While it's unclear how Portal events will be used off-chain, it's more likely to search and filter events by `sender`, `recipient` and `chainId`, rather than `messageId`, which is unique per message.

