### PR TITLE
refactor: move index check to Portal

### DIFF
--- a/src/SpokePortal.sol
+++ b/src/SpokePortal.sol
@@ -50,7 +50,9 @@ contract SpokePortal is ISpokePortal, Portal {
 
         emit MTokenIndexReceived(messageId_, index_);
 
-        ISpokeMTokenLike(mToken()).updateIndex(index_);
+        if (index_ > _currentIndex()) {
+            ISpokeMTokenLike(mToken()).updateIndex(index_);
+        }
     }
 
     /// @notice Sets a Registrar key received from the Hub chain.
@@ -86,7 +88,12 @@ contract SpokePortal is ISpokePortal, Portal {
      * @param index_     The index from the source chain.
      */
     function _mintOrUnlock(address recipient_, uint256 amount_, uint128 index_) internal override {
-        ISpokeMTokenLike(mToken()).mint(recipient_, amount_, index_);
+        // Update M token index only if the index received from the remote chain is bigger
+        if (index_ > _currentIndex()) {
+            ISpokeMTokenLike(mToken()).mint(recipient_, amount_, index_);
+        } else {
+            ISpokeMTokenLike(mToken()).mint(recipient_, amount_);
+        }
     }
 
     /// @dev Returns the current M token index used by the Spoke Portal.

--- a/src/interfaces/ISpokeMTokenLike.sol
+++ b/src/interfaces/ISpokeMTokenLike.sol
@@ -10,6 +10,14 @@ import { IMTokenLike } from "./IMTokenLike.sol";
  */
 interface ISpokeMTokenLike is IMTokenLike {
     /**
+     * @notice Mints tokens.
+     * @dev    MUST only be callable by the SpokePortal.
+     * @param  account The address of account to mint to.
+     * @param  amount  The amount of M Token to mint.
+     */
+    function mint(address account, uint256 amount) external;
+
+    /**
      * @notice Updates the index and mints tokens.
      * @dev    MUST only be callable by the SpokePortal.
      * @param  account The address of account to mint to.

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -56,7 +56,7 @@ abstract contract MockERC20 {
         return true;
     }
 
-    function mintTo(address to, uint256 amount) external {
+    function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
 

--- a/test/unit/HubPortal.t.sol
+++ b/test/unit/HubPortal.t.sol
@@ -295,7 +295,7 @@ contract HubPortalTests is UnitTestBase {
         uint256 fee_ = 1;
 
         vm.deal(_alice, fee_);
-        _mToken.mintTo(_alice, amount_);
+        _mToken.mint(_alice, amount_);
 
         vm.startPrank(_alice);
         _mToken.approve(address(_portal), amount_);
@@ -311,7 +311,7 @@ contract HubPortalTests is UnitTestBase {
         uint256 amount_ = 1_000e6;
         uint128 remoteIndex_ = _EXP_SCALED_ONE;
 
-        _mToken.mintTo(address(_portal), amount_);
+        _mToken.mint(address(_portal), amount_);
 
         (TransceiverStructs.NttManagerMessage memory message_, ) = _createTransferMessage(
             amount_,
@@ -334,7 +334,7 @@ contract HubPortalTests is UnitTestBase {
         amount_ = uint240(bound(amount_, 1, _getMaxTransferAmount(_tokenDecimals)));
 
         _mToken.setCurrentIndex(localIndex_);
-        _mToken.mintTo(address(_portal), amount_);
+        _mToken.mint(address(_portal), amount_);
 
         (TransceiverStructs.NttManagerMessage memory message_, ) = _createTransferMessage(
             amount_,
@@ -358,7 +358,7 @@ contract HubPortalTests is UnitTestBase {
         _mToken.setCurrentIndex(localIndex_);
         _mToken.setIsEarning(_alice, true);
         _mToken.setIsEarning(address(_portal), true);
-        _mToken.mintTo(address(_portal), amount_);
+        _mToken.mint(address(_portal), amount_);
 
         (TransceiverStructs.NttManagerMessage memory message_, ) = _createTransferMessage(
             amount_,
@@ -382,7 +382,7 @@ contract HubPortalTests is UnitTestBase {
         _mToken.setCurrentIndex(localIndex_);
         _mToken.setIsEarning(_alice, true);
         _mToken.setIsEarning(address(_portal), true);
-        _mToken.mintTo(address(_portal), amount_);
+        _mToken.mint(address(_portal), amount_);
 
         (TransceiverStructs.NttManagerMessage memory message_, ) = _createTransferMessage(
             amount_,
@@ -407,7 +407,7 @@ contract HubPortalTests is UnitTestBase {
         _mToken.setCurrentIndex(localIndex_);
         _mToken.setIsEarning(address(_portal), true);
         _mToken.setIsEarning(_alice, true);
-        _mToken.mintTo(address(_portal), amount_);
+        _mToken.mint(address(_portal), amount_);
 
         (TransceiverStructs.NttManagerMessage memory message_, ) = _createTransferMessage(
             amount_,

--- a/test/unit/Portal.t.sol
+++ b/test/unit/Portal.t.sol
@@ -88,7 +88,7 @@ contract PortalTests is UnitTestBase {
         );
 
         vm.deal(_alice, msgValue_);
-        _mToken.mintTo(_alice, amount_);
+        _mToken.mint(_alice, amount_);
 
         vm.startPrank(_alice);
         _mToken.approve(address(_portal), amount_);

--- a/test/unit/SpokePortal.t.sol
+++ b/test/unit/SpokePortal.t.sol
@@ -137,7 +137,7 @@ contract SpokePortalTests is UnitTestBase {
     function test_sendMToken() external {
         uint256 amount_ = 1_000e6;
 
-        _mToken.mintTo(_alice, amount_);
+        _mToken.mint(_alice, amount_);
 
         vm.startPrank(_alice);
         _mToken.approve(address(_portal), amount_);
@@ -164,7 +164,7 @@ contract SpokePortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
 
-        vm.expectCall(address(_mToken), abi.encodeCall(_mToken.mint, (_alice, amount_, remoteIndex_)));
+        vm.expectCall(address(_mToken), abi.encodeWithSignature("mint(address,uint256)", _alice, amount_));
 
         vm.prank(address(_transceiver));
         _portal.attestationReceived(_REMOTE_CHAIN_ID, _PEER, message_);
@@ -185,7 +185,11 @@ contract SpokePortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
 
-        vm.expectCall(address(_mToken), abi.encodeCall(_mToken.mint, (_alice, amount_, remoteIndex_)));
+        bytes memory call = remoteIndex_ > localIndex_
+            ? abi.encodeWithSignature("mint(address,uint256,uint128)", _alice, amount_, remoteIndex_)
+            : abi.encodeWithSignature("mint(address,uint256)", _alice, amount_);
+
+        vm.expectCall(address(_mToken), call);
 
         vm.prank(address(_transceiver));
         _portal.attestationReceived(_REMOTE_CHAIN_ID, _PEER, message_);
@@ -207,7 +211,7 @@ contract SpokePortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
 
-        vm.expectCall(address(_mToken), abi.encodeCall(_mToken.mint, (_alice, amount_, remoteIndex_)));
+        vm.expectCall(address(_mToken), abi.encodeWithSignature("mint(address,uint256)", _alice, amount_));
 
         vm.prank(address(_transceiver));
         _portal.attestationReceived(_REMOTE_CHAIN_ID, _PEER, message_);
@@ -229,7 +233,7 @@ contract SpokePortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
 
-        vm.expectCall(address(_mToken), abi.encodeCall(_mToken.mint, (_alice, amount_, remoteIndex_)));
+        vm.expectCall(address(_mToken), abi.encodeWithSignature("mint(address,uint256)", _alice, amount_));
 
         vm.prank(address(_transceiver));
         _portal.attestationReceived(_REMOTE_CHAIN_ID, _PEER, message_);
@@ -251,7 +255,10 @@ contract SpokePortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
 
-        vm.expectCall(address(_mToken), abi.encodeCall(_mToken.mint, (_alice, amount_, remoteIndex_)));
+        vm.expectCall(
+            address(_mToken),
+            abi.encodeWithSignature("mint(address,uint256,uint128)", _alice, amount_, remoteIndex_)
+        );
 
         vm.prank(address(_transceiver));
         _portal.attestationReceived(_REMOTE_CHAIN_ID, _PEER, message_);
@@ -273,7 +280,11 @@ contract SpokePortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
 
-        vm.expectCall(address(_mToken), abi.encodeCall(_mToken.mint, (_alice, amount_, remoteIndex_)));
+        bytes memory call = remoteIndex_ > localIndex_
+            ? abi.encodeWithSignature("mint(address,uint256,uint128)", _alice, amount_, remoteIndex_)
+            : abi.encodeWithSignature("mint(address,uint256)", _alice, amount_);
+
+        vm.expectCall(address(_mToken), call);
 
         vm.prank(address(_transceiver));
         _portal.attestationReceived(_REMOTE_CHAIN_ID, _PEER, message_);


### PR DESCRIPTION
### Proposed changes:
- add index validation check to `_mintOrUnlock` function in SpokePortal.
- add index validation check to `_updateMTokenIndex` function in SpokePortal.
- add mint function that doesn't take index to `ISpokeMTokenLike`

### Related PR:
https://github.com/m0-foundation/protocol/pull/194/


