### PR TITLE
fix: remove transceiver instructions parameter

### DIFF
--- a/script/cast/CastBase.sol
+++ b/script/cast/CastBase.sol
@@ -24,8 +24,7 @@ contract CastBase is Script, Utils {
         bytes32 refundAddress_,
         uint256 value_
     ) internal returns (bytes32 messageId_) {
-        return
-            IHubPortal(hubPortal_).sendMTokenIndex{ value: value_ }(destinationChainId_, refundAddress_, new bytes(1));
+        return IHubPortal(hubPortal_).sendMTokenIndex{ value: value_ }(destinationChainId_, refundAddress_);
     }
 
     function _sendRegistrarKey(
@@ -35,13 +34,7 @@ contract CastBase is Script, Utils {
         bytes32 refundAddress_,
         uint256 value_
     ) internal returns (bytes32 messageId_) {
-        return
-            IHubPortal(hubPortal_).sendRegistrarKey{ value: value_ }(
-                destinationChainId_,
-                key_,
-                refundAddress_,
-                new bytes(1)
-            );
+        return IHubPortal(hubPortal_).sendRegistrarKey{ value: value_ }(destinationChainId_, key_, refundAddress_);
     }
 
     function _sendRegistrarListStatus(
@@ -57,8 +50,7 @@ contract CastBase is Script, Utils {
                 destinationChainId_,
                 listName_,
                 account_,
-                refundAddress_,
-                new bytes(1)
+                refundAddress_
             );
     }
 }

--- a/src/interfaces/IHubPortal.sol
+++ b/src/interfaces/IHubPortal.sol
@@ -79,28 +79,21 @@ interface IHubPortal is IPortal {
      * @notice Sends the M token index to the destination chain.
      * @param  destinationChainId      The Wormhole destination chain ID.
      * @param  refundAddress           Refund address to receive excess native gas.
-     * @param  transceiverInstructions Additional instructions to be forwarded to the destination chain.
      * @return ID uniquely identifying the message
      */
-    function sendMTokenIndex(
-        uint16 destinationChainId,
-        bytes32 refundAddress,
-        bytes memory transceiverInstructions
-    ) external payable returns (bytes32);
+    function sendMTokenIndex(uint16 destinationChainId, bytes32 refundAddress) external payable returns (bytes32);
 
     /**
      * @notice Sends the Registrar key to the destination chain.
      * @param  destinationChainId      The Wormhole destination chain ID.
      * @param  key                     The key to dispatch.
      * @param  refundAddress           Refund address to receive excess native gas.
-     * @param  transceiverInstructions Additional instructions to be forwarded to the destination chain.
      * @return ID uniquely identifying the message
      */
     function sendRegistrarKey(
         uint16 destinationChainId,
         bytes32 key,
-        bytes32 refundAddress,
-        bytes memory transceiverInstructions
+        bytes32 refundAddress
     ) external payable returns (bytes32);
 
     /**
@@ -109,15 +102,13 @@ interface IHubPortal is IPortal {
      * @param  listName                The name of the list.
      * @param  account                 The account.
      * @param  refundAddress           Refund address to receive excess native gas.
-     * @param  transceiverInstructions Additional instructions to be forwarded to the destination chain.
      * @return ID uniquely identifying the message
      */
     function sendRegistrarListStatus(
         uint16 destinationChainId,
         bytes32 listName,
         address account,
-        bytes32 refundAddress,
-        bytes memory transceiverInstructions
+        bytes32 refundAddress
     ) external payable returns (bytes32);
 
     /// @notice Enables earning for the Hub Portal if allowed by TTG.

--- a/test/unit/HubPortal.t.sol
+++ b/test/unit/HubPortal.t.sol
@@ -188,7 +188,7 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.MTokenIndexSent(_REMOTE_CHAIN_ID, messageId_, index_);
 
         vm.prank(_alice);
-        _portal.sendMTokenIndex{ value: fee_ }(_REMOTE_CHAIN_ID, refundAddress_, _encodedEmptyTransceiverInstructions);
+        _portal.sendMTokenIndex{ value: fee_ }(_REMOTE_CHAIN_ID, refundAddress_);
     }
 
     /* ============ sendRegistrarKey ============ */
@@ -226,12 +226,7 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.RegistrarKeySent(_REMOTE_CHAIN_ID, messageId_, key_, value_);
 
         vm.prank(_alice);
-        _portal.sendRegistrarKey{ value: fee_ }(
-            _REMOTE_CHAIN_ID,
-            key_,
-            refundAddress_,
-            _encodedEmptyTransceiverInstructions
-        );
+        _portal.sendRegistrarKey{ value: fee_ }(_REMOTE_CHAIN_ID, key_, refundAddress_);
     }
 
     /* ============ sendRegistrarListStatus ============ */
@@ -270,13 +265,7 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.RegistrarListStatusSent(_REMOTE_CHAIN_ID, messageId_, listName_, account_, status_);
 
         vm.prank(_alice);
-        _portal.sendRegistrarListStatus{ value: fee_ }(
-            _REMOTE_CHAIN_ID,
-            listName_,
-            account_,
-            refundAddress_,
-            _encodedEmptyTransceiverInstructions
-        );
+        _portal.sendRegistrarListStatus{ value: fee_ }(_REMOTE_CHAIN_ID, listName_, account_, refundAddress_);
     }
 
     /* ============ transfer ============ */


### PR DESCRIPTION
### Proposed Changes:

- remove `transceiverInstructions` parameter from `sendMTokenIndex`, `sendRegistrarKey` and `sendRegistrarListStatus` in `HubPortal`
- use the default transceiver instructions instead (`new bytes(1)`), so callers are unable to override the default relaying mechanism.