### PR TITLE
fix: enable/disable earning in HubPortal

### DIFF
--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.26;
 
 import { IERC20 } from "../lib/common/src/interfaces/IERC20.sol";
+import { IndexingMath } from "../lib/common/src/libs/IndexingMath.sol";
 import { TransceiverStructs } from "../lib/example-native-token-transfers/evm/src/libraries/TransceiverStructs.sol";
 
 import { IMTokenLike } from "./interfaces/IMTokenLike.sol";
@@ -31,8 +32,11 @@ contract HubPortal is IHubPortal, Portal {
     /// @dev Registrar key of earners list.
     bytes32 internal constant _EARNERS_LIST = "earners";
 
-    /// @dev Array of indices at which earning was enabled or disabled.
-    uint128[] internal _enableDisableEarningIndices;
+    /// @dev The Hub Portal's index when earning was most recently disabled
+    uint128 public _disablePortalIndex;
+
+    // The M token's index when earning was most recently enabled
+    uint128 public _enableMTokenIndex;
 
     /* ============ Constructor ============ */
 
@@ -47,6 +51,15 @@ contract HubPortal is IHubPortal, Portal {
         address registrar_,
         uint16 chainId_
     ) Portal(mToken_, registrar_, Mode.LOCKING, chainId_) {}
+
+    function _initialize() internal override {
+        super._initialize();
+
+        // set _disablePortalIndex to the default value on first deployment
+        if (_disablePortalIndex == 0) {
+            _disablePortalIndex = IndexingMath.EXP_SCALED_ONE;
+        }
+    }
 
     /* ============ Interactive Functions ============ */
 
@@ -91,34 +104,27 @@ contract HubPortal is IHubPortal, Portal {
 
     /// @inheritdoc IHubPortal
     function enableEarning() external {
-        if (!_isApprovedEarner()) revert NotApprovedEarner();
         if (_isEarningEnabled()) revert EarningIsEnabled();
 
-        // NOTE: This is a temporary measure to prevent re-enabling earning after it has been disabled.
-        //       This line will be removed in the future.
-        if (_enableDisableEarningIndices.length != 0) revert EarningCannotBeReenabled();
+        uint128 mTokenIndex_ = _currentMTokenIndex();
+        _enableMTokenIndex = mTokenIndex_;
 
-        IMTokenLike mToken_ = IMTokenLike(mToken());
-        uint128 currentMIndex_ = mToken_.currentIndex();
-        _enableDisableEarningIndices.push(currentMIndex_);
+        IMTokenLike(mToken()).startEarning();
 
-        mToken_.startEarning();
-
-        emit EarningEnabled(currentMIndex_);
+        emit EarningEnabled(mTokenIndex_);
     }
 
     /// @inheritdoc IHubPortal
     function disableEarning() external {
-        if (_isApprovedEarner()) revert IsApprovedEarner();
         if (!_isEarningEnabled()) revert EarningIsDisabled();
 
-        IMTokenLike mToken_ = IMTokenLike(mToken());
-        uint128 currentMIndex_ = mToken_.currentIndex();
-        _enableDisableEarningIndices.push(currentMIndex_);
+        uint128 portalIndex_ = _currentIndex();
+        _disablePortalIndex = portalIndex_;
+        _enableMTokenIndex = 0;
 
-        mToken_.stopEarning();
+        IMTokenLike(mToken()).stopEarning(address(this));
 
-        emit EarningDisabled(currentMIndex_);
+        emit EarningDisabled(portalIndex_);
     }
 
     /* ============ Internal Interactive Functions ============ */
@@ -168,33 +174,22 @@ contract HubPortal is IHubPortal, Portal {
         return TransceiverStructs.nttManagerMessageDigest(chainId, message_);
     }
 
-    /* ============ Internal View/Pure Functions ============ */
+    /* ============ Internal/Private View Functions ============ */
 
-    /// @dev Returns the current M token index used by the Hub Portal.
+    /// @dev Returns the current Hub Portal index
     function _currentIndex() internal view override returns (uint128) {
-        if (_isEarningEnabled()) {
-            return IMTokenLike(mToken()).currentIndex();
-        }
-
-        // If earning has been enabled in the past, return the latest recorded index when it was disabled.
-        // Otherwise, return the starting index.
         return
-            _enableDisableEarningIndices.length != 0
-                ? _enableDisableEarningIndices[_enableDisableEarningIndices.length - 1]
-                : 0;
+            _isEarningEnabled()
+                ? (_disablePortalIndex * _currentMTokenIndex()) / _enableMTokenIndex
+                : _disablePortalIndex;
     }
 
-    /// @dev Returns whether the Hub Portal is a TTG-approved earner or not.
-    function _isApprovedEarner() internal view returns (bool) {
-        IRegistrarLike registrar_ = IRegistrarLike(registrar);
-
-        return
-            registrar_.get(_EARNERS_LIST_IGNORED) != bytes32(0) ||
-            registrar_.listContains(_EARNERS_LIST, address(this));
+    function _currentMTokenIndex() private view returns (uint128 index_) {
+        return IMTokenLike(mToken()).currentIndex();
     }
 
     /// @dev Returns whether earning was enabled for HubPortal or not.
-    function _isEarningEnabled() internal view returns (bool) {
-        return IMTokenLike(mToken()).isEarning(address(this));
+    function _isEarningEnabled() public view returns (bool) {
+        return _enableMTokenIndex != 0;
     }
 }

--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.26;
 
 import { IERC20 } from "../lib/common/src/interfaces/IERC20.sol";
+import { UIntMath } from "../lib/common/src/libs/UIntMath.sol";
 import { IndexingMath } from "../lib/common/src/libs/IndexingMath.sol";
 import { TransceiverStructs } from "../lib/example-native-token-transfers/evm/src/libraries/TransceiverStructs.sol";
 
@@ -174,11 +175,12 @@ contract HubPortal is IHubPortal, Portal {
     function _currentIndex() internal view override returns (uint128) {
         return
             _isEarningEnabled()
-                ? uint128(uint256(_disablePortalIndex) * _currentMTokenIndex()) / _enableMTokenIndex
+                ? UIntMath.bound128((uint256(_disablePortalIndex) * _currentMTokenIndex()) / _enableMTokenIndex)
                 : _disablePortalIndex;
     }
 
-    function _currentMTokenIndex() private view returns (uint128 index_) {
+    /// @dev Returns the current M Token index
+    function _currentMTokenIndex() private view returns (uint128) {
         return IMTokenLike(mToken()).currentIndex();
     }
 

--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -26,17 +26,11 @@ contract HubPortal is IHubPortal, Portal {
 
     /* ============ Variables ============ */
 
-    /// @dev Registrar key holding value of whether the earners list can be ignored or not.
-    bytes32 internal constant _EARNERS_LIST_IGNORED = "earners_list_ignored";
-
-    /// @dev Registrar key of earners list.
-    bytes32 internal constant _EARNERS_LIST = "earners";
-
     /// @dev The Hub Portal's index when earning was most recently disabled
-    uint128 public _disablePortalIndex;
+    uint128 private _disablePortalIndex;
 
-    // The M token's index when earning was most recently enabled
-    uint128 public _enableMTokenIndex;
+    /// @dev The M token's index when earning was most recently enabled
+    uint128 private _enableMTokenIndex;
 
     /* ============ Constructor ============ */
 
@@ -180,7 +174,7 @@ contract HubPortal is IHubPortal, Portal {
     function _currentIndex() internal view override returns (uint128) {
         return
             _isEarningEnabled()
-                ? (_disablePortalIndex * _currentMTokenIndex()) / _enableMTokenIndex
+                ? uint128(uint256(_disablePortalIndex) * _currentMTokenIndex()) / _enableMTokenIndex
                 : _disablePortalIndex;
     }
 
@@ -189,7 +183,7 @@ contract HubPortal is IHubPortal, Portal {
     }
 
     /// @dev Returns whether earning was enabled for HubPortal or not.
-    function _isEarningEnabled() public view returns (bool) {
+    function _isEarningEnabled() private view returns (bool) {
         return _enableMTokenIndex != 0;
     }
 }

--- a/src/interfaces/IMTokenLike.sol
+++ b/src/interfaces/IMTokenLike.sol
@@ -20,6 +20,6 @@ interface IMTokenLike {
     /// @notice Starts earning for caller if allowed by TTG.
     function startEarning() external;
 
-    /// @notice Stops earning for caller.
-    function stopEarning() external;
+    /// @notice Stops earning for the account.
+    function stopEarning(address account_) external;
 }

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -57,7 +57,7 @@ contract HubPortalForkTests is ForkTestBase {
         _deliverMessage(_BASE_WORMHOLE_RELAYER, signedMessage_);
 
         assertEq(IERC20(_baseSpokeMToken).balanceOf(_mHolder), amount_);
-        assertEq(IContinuousIndexing(_baseSpokeMToken).currentIndex(), mainnetIndex_);
+        assertEq(IContinuousIndexing(_baseSpokeMToken).currentIndex(), _EXP_SCALED_ONE);
     }
 
     /* ============ sendMTokenIndex ============ */
@@ -88,8 +88,8 @@ contract HubPortalForkTests is ForkTestBase {
 
         _deliverMessage(_BASE_WORMHOLE_RELAYER, signedMessage_);
 
-        assertEq(IPortal(_baseSpokePortal).currentIndex(), mainnetIndex_);
-        assertEq(IContinuousIndexing(_baseSpokeMToken).currentIndex(), mainnetIndex_);
+        assertEq(IPortal(_baseSpokePortal).currentIndex(), _EXP_SCALED_ONE);
+        assertEq(IContinuousIndexing(_baseSpokeMToken).currentIndex(), _EXP_SCALED_ONE);
 
         vm.stopPrank();
     }
@@ -169,7 +169,7 @@ contract HubPortalForkTests is ForkTestBase {
         vm.selectFork(_mainnetForkId);
 
         uint128 mainnetIndex_ = IContinuousIndexing(_MAINNET_M_TOKEN).currentIndex();
-        assertEq(IHubPortal(_hubPortal).currentIndex(), mainnetIndex_);
+        assertEq(IHubPortal(_hubPortal).currentIndex(), _EXP_SCALED_ONE);
 
         // Disable earning for the Hub Portal
         vm.mockCall(
@@ -183,7 +183,6 @@ contract HubPortalForkTests is ForkTestBase {
         // Move forward by 7 days
         vm.warp(block.timestamp + 604800);
 
-        assertEq(IHubPortal(_hubPortal).currentIndex(), mainnetIndex_);
-        assertGt(IContinuousIndexing(_MAINNET_M_TOKEN).currentIndex(), IHubPortal(_hubPortal).currentIndex());
+        assertEq(IHubPortal(_hubPortal).currentIndex(), _EXP_SCALED_ONE);
     }
 }

--- a/test/fork/SpokePortalFork.t.sol
+++ b/test/fork/SpokePortalFork.t.sol
@@ -81,7 +81,7 @@ contract SpokePortalForkTests is ForkTestBase {
         _deliverMessage(_OPTIMISM_WORMHOLE_RELAYER, spokeSignedMessage_);
 
         assertEq(IERC20(_optimismSpokeMToken).balanceOf(_mHolder), _amount);
-        assertEq(IContinuousIndexing(_optimismSpokeMToken).currentIndex(), _mainnetIndex);
+        assertEq(IContinuousIndexing(_optimismSpokeMToken).currentIndex(), _EXP_SCALED_ONE);
     }
 
     function _beforeTest() internal {
@@ -117,7 +117,7 @@ contract SpokePortalForkTests is ForkTestBase {
         _deliverMessage(_BASE_WORMHOLE_RELAYER, hubSignedMessage_);
 
         assertEq(IERC20(_baseSpokeMToken).balanceOf(_mHolder), _amount);
-        assertEq(IContinuousIndexing(_baseSpokeMToken).currentIndex(), _mainnetIndex);
+        assertEq(IContinuousIndexing(_baseSpokeMToken).currentIndex(), _EXP_SCALED_ONE);
 
         // TODO: add excess test once underflow has been fixed
         // ISpokePortal(_baseSpokePortal).excess();

--- a/test/mocks/MockMToken.sol
+++ b/test/mocks/MockMToken.sol
@@ -19,7 +19,11 @@ contract MockMToken is MockERC20 {
         isEarning[account_] = isEarning_;
     }
 
-    function startEarning() external {}
+    function startEarning() external {
+        isEarning[msg.sender] = true;
+    }
 
-    function stopEarning() external {}
+    function stopEarning(address account_) external {
+        isEarning[account_] = false;
+    }
 }


### PR DESCRIPTION
### Proposed changes:

- remove `isApproveEarner` check from `enableEarning()` and `disableEarning()` functions, since the same check already exists in `MToken` `startEarning()` and `stopEarning(address)` functions.
- implement "virtual index" for `HubPortal` calculated proportionally to the current M Token index.

### Benefits of "virtual index":
- allows re-enabling earning after it was disabled.
- fixes **_Kirill M-01_** finding since Spoke Token index won't "jump" from `EXP_SCALE_ONE` to the latest current index on the Hub but will be increased gradually.

### Drawbacks of "virtual index":
- M Token index on Spoke chains will be different from M Token index on the Hub chain, which might confuse users and integrators.