### PR TITLE
feat: update HubPortal to support Solana

### DIFF
--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -189,7 +189,7 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         // burns M tokens on Spoke. In case of Hub, tokens are already transferred
         _burnOrLock(amount_);
 
-        sequence_ = _transferNativeToken(
+        (sequence_, ) = _transferNativeToken(
             amount_,
             sourceToken_,
             destinationChainId_,
@@ -221,10 +221,10 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         bytes32 recipient_,
         bytes32 refundAddress_,
         bytes memory additionalPayload_
-    ) internal returns (uint64 sequence_) {
+    ) internal returns (uint64 sequence_, bytes32 messageId_) {
         sequence_ = _useMessageSequence();
-
-        (TransceiverStructs.NttManagerMessage memory message_, bytes32 messageId_) = _encodeTokenTransfer(
+        TransceiverStructs.NttManagerMessage memory message_;
+        (message_, messageId_) = _encodeTokenTransfer(
             _trimTransferAmount(amount_, destinationChainId_),
             destinationChainId_,
             msg.sender,

--- a/src/interfaces/IHubPortal.sol
+++ b/src/interfaces/IHubPortal.sol
@@ -63,11 +63,11 @@ interface IHubPortal is IPortal {
     event MerkleTreeBuilderSet(address merkleTreeBuilder);
 
     /**
-     * @notice Emitted when earners and earn managers Merkle roots are sent to Solana.
+     * @notice Emitted when earners Merkle root is sent to Solana.
+     * @param  messageId         The unique identifier for the sent message.
      * @param  earnersMerkleRoot The Merkle root of earners.
-     * @param  earnManagersMerkleRoot The Merkle root of earn managers.
      */
-    event MerkleRootsSent(bytes32 earnersMerkleRoot, bytes32 earnManagersMerkleRoot);
+    event EarnersMerkleRootSent(bytes32 messageId, bytes32 earnersMerkleRoot);
 
     /* ============ Custom Errors ============ */
 
@@ -89,6 +89,9 @@ interface IHubPortal is IPortal {
     /// @notice Emitted when calling `setMerkleTreeBuilder` if Merkle Tree Builder address is 0x0.
     error ZeroMerkleTreeBuilder();
 
+    /// @notice Emitted when the destination chain is not supported
+    error UnsupportedDestinationChain(uint16 destinationChainId);
+
     /* ============ View/Pure Functions ============ */
 
     /// @notice Indicates whether earning for HubPortal was ever enabled.
@@ -104,46 +107,51 @@ interface IHubPortal is IPortal {
 
     /**
      * @notice Sends the M token index to the destination chain.
-     * @param  destinationChainId      The Wormhole destination chain ID.
-     * @param  refundAddress           Refund address to receive excess native gas.
-     * @return ID uniquely identifying the message
+     * @param  destinationChainId The Wormhole destination chain ID.
+     * @param  refundAddress      The refund address to receive excess native gas.
+     * @return messageId          The ID uniquely identifying the message.
      */
-    function sendMTokenIndex(uint16 destinationChainId, bytes32 refundAddress) external payable returns (bytes32);
+    function sendMTokenIndex(
+        uint16 destinationChainId,
+        bytes32 refundAddress
+    ) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sends the Registrar key to the destination chain.
-     * @param  destinationChainId      The Wormhole destination chain ID.
-     * @param  key                     The key to dispatch.
-     * @param  refundAddress           Refund address to receive excess native gas.
-     * @return ID uniquely identifying the message
+     * @dev    Not supported for Solana.
+     * @param  destinationChainId The Wormhole destination chain ID.
+     * @param  key                The key to dispatch.
+     * @param  refundAddress      The refund address to receive excess native gas.
+     * @return messageId          The ID uniquely identifying the message
      */
     function sendRegistrarKey(
         uint16 destinationChainId,
         bytes32 key,
         bytes32 refundAddress
-    ) external payable returns (bytes32);
+    ) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sends the Registrar list status for an account to the destination chain.
-     * @param  destinationChainId      The Wormhole destination chain ID.
-     * @param  listName                The name of the list.
-     * @param  account                 The account.
-     * @param  refundAddress           Refund address to receive excess native gas.
-     * @return ID uniquely identifying the message
+     * @dev    Not supported for Solana.
+     * @param  destinationChainId The Wormhole destination chain ID.
+     * @param  listName           The name of the list.
+     * @param  account            The account.
+     * @param  refundAddress      The refund address to receive excess native gas.
+     * @return messageId          The ID uniquely identifying the message.
      */
     function sendRegistrarListStatus(
         uint16 destinationChainId,
         bytes32 listName,
         address account,
         bytes32 refundAddress
-    ) external payable returns (bytes32);
+    ) external payable returns (bytes32 messageId);
 
     /**
-     * @notice Sends earners and earn managers Merkle roots to Solana.
-     * @param  refundAddress Refund address to receive excess native gas.
-     * @return sequence      The message sequence.
+     * @notice Sends earners Merkle root to Solana.
+     * @param  refundAddress The refund address to receive excess native gas.
+     * @return messageId     The ID uniquely identifying the message.
      */
-    function sendMerkleRoots(bytes32 refundAddress) external payable returns (uint64 sequence);
+    function sendEarnersMerkleRoot(bytes32 refundAddress) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sets Merkle Tree Builder contract.

--- a/src/libs/PayloadEncoder.sol
+++ b/src/libs/PayloadEncoder.sol
@@ -75,10 +75,9 @@ library PayloadEncoder {
     function encodeAdditionalPayload(
         uint128 index_,
         bytes32 destinationToken_,
-        bytes32 earnerMerkleRoot_,
-        bytes32 earnManagerMerkleRoot_
+        bytes32 earnersMerkleRoot_
     ) internal pure returns (bytes memory encoded_) {
-        return abi.encodePacked(index_.toUint64(), destinationToken_, earnerMerkleRoot_, earnManagerMerkleRoot_);
+        return abi.encodePacked(index_.toUint64(), destinationToken_, earnersMerkleRoot_);
     }
 
     function decodeAdditionalPayload(

--- a/test/unit/UnitTestBase.t.sol
+++ b/test/unit/UnitTestBase.t.sol
@@ -93,20 +93,14 @@ contract UnitTestBase is Test {
         uint16 sourceChainId_,
         uint16 destinationChainId_,
         bytes32 destinationToken_,
-        bytes32 earnersMerkleRoot_,
-        bytes32 earnManagersMerkleRoot_
+        bytes32 earnersMerkleRoot_
     ) internal view returns (TransceiverStructs.NttManagerMessage memory message_, bytes32 messageId_) {
         TransceiverStructs.NativeTokenTransfer memory nativeTokenTransfer_ = TransceiverStructs.NativeTokenTransfer(
             0.trim(_tokenDecimals, _tokenDecimals),
             _tokenAddress.toBytes32(),
             recipient_,
             destinationChainId_,
-            PayloadEncoder.encodeAdditionalPayload(
-                index_,
-                destinationToken_,
-                earnersMerkleRoot_,
-                earnManagersMerkleRoot_
-            )
+            PayloadEncoder.encodeAdditionalPayload(index_, destinationToken_, earnersMerkleRoot_)
         );
         bytes memory payload_ = TransceiverStructs.encodeNativeTokenTransfer(nativeTokenTransfer_);
         message_ = TransceiverStructs.NttManagerMessage(bytes32(0), _alice.toBytes32(), payload_);


### PR DESCRIPTION
### Proposed changes:

- remove Earner Manager Merkle root propagation
- send $M Index to Solana as an additional payload with zero token transfer
- revert if `sendRegistrarListStatus` or `sendRegistrarKey` functions are called for Solana