### PR TITLE
Feat: exact transfer of $M in HubPortal

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run lint-staged && npm test
+npm run lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run lint-staged
+npm run lint-staged && npm test

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -186,11 +186,14 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         // Accounts for potential rounding errors when transferring between earners and non-earners
         uint256 actualAmount_ = mToken_.balanceOf(address(this)) - startingBalance_;
 
-        // Burns the actual amount of M tokens on Spoke.
-        // In case of Hub, tokens are already transferred
+        // Burn the actual amount of M tokens on Spoke.
+        // In case of Hub, do nothing, as tokens are already transferred.
         _burnOrLock(actualAmount_);
 
-        // NOTE: transfers the exact amount ignoring potential rounding error
+        // NOTE: transfers the exact amount ignoring potential rounding errors to improve the experience for the sender.
+        // Since HubPortal is an earner the deficit is covered from the yield earned by HubPortal.
+        // M extensions registered in the Portal must not have fee-on-transfer functionality
+        // as it will lead to an exploit when using exact transfers.
         (sequence_, ) = _transferNativeToken(
             amount_,
             sourceToken_,

--- a/test/fork/ForkTestBase.t.sol
+++ b/test/fork/ForkTestBase.t.sol
@@ -6,6 +6,7 @@ import { Test } from "../../lib/forge-std/src/Test.sol";
 import { Vm } from "../../lib/forge-std/src/Test.sol";
 
 import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
+import { WrappedMToken } from "../../lib/wrapped-m-token/src/WrappedMToken.sol";
 
 import {
     IWormholeRelayer
@@ -334,6 +335,16 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
         );
 
         _deliverMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM, spokeForkId_, spokeRelayer_);
+    }
+
+    function _enableWrappedMEarning(address wrappedMToken_, address registrar_) internal {
+        vm.mockCall(
+            registrar_,
+            abi.encodeWithSelector(IRegistrarLike.listContains.selector, bytes32("earners"), wrappedMToken_),
+            abi.encode(true)
+        );
+
+        WrappedMToken(wrappedMToken_).enableEarning();
     }
 
     function _transfer(

--- a/test/fork/ForkTestBase.t.sol
+++ b/test/fork/ForkTestBase.t.sol
@@ -27,6 +27,7 @@ import { WormholeConfig, WormholeTransceiverConfig } from "../../script/config/W
 import { PeersConfig, PeerConfig } from "../../script/config/PeersConfig.sol";
 
 import { TypeConverter } from "../../src/libs/TypeConverter.sol";
+import { IPortal } from "../../src/interfaces/IPortal.sol";
 import { IMTokenLike } from "../../src/interfaces/IMTokenLike.sol";
 import { IHubPortal } from "../../src/interfaces/IHubPortal.sol";
 import { IRegistrarLike } from "../../src/interfaces/IRegistrarLike.sol";
@@ -59,7 +60,7 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
     address internal immutable _alice = makeAddr("alice");
     address internal immutable _bob = makeAddr("bob");
     address internal immutable _mHolder = 0x3f0376da3Ae4313E7a5F1dA184BAFC716252d759;
-    address internal immutable _wrappedMHolder = 0x6AaA90D689942b5eaB3D8433f2E02B32a0214390;
+    address internal immutable _wrappedMHolder = 0x13Ccb6E28F22E2f6783BaDedCe32cc74583A3647;
 
     TransceiverStructs.TransceiverInstruction internal _emptyTransceiverInstruction =
         TransceiverStructs.TransceiverInstruction({ index: 0, payload: "" });
@@ -356,6 +357,31 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
             _quoteDeliveryPrice(portal_, destinationChainId_)
         );
 
+        vm.stopPrank();
+    }
+
+    function _transferMLikeToken(
+        address sourceToken_,
+        address destinationToken_,
+        uint256 amount_,
+        address sender_,
+        address recipient_,
+        address portal_,
+        uint16 destinationChainId_
+    ) internal {
+        vm.startPrank(sender_);
+        vm.recordLogs();
+
+        IERC20(sourceToken_).approve(_hubPortal, amount_);
+
+        IPortal(portal_).transferMLikeToken{ value: _quoteDeliveryPrice(portal_, destinationChainId_) }(
+            amount_,
+            sourceToken_,
+            destinationChainId_,
+            destinationToken_.toBytes32(),
+            recipient_.toBytes32(),
+            recipient_.toBytes32()
+        );
         vm.stopPrank();
     }
 

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -352,6 +352,114 @@ contract HubPortalForkTests is ForkTestBase {
         });
     }
 
+    /// @dev Transferring WrappedM to M
+    ///      Sender is earner, Hub is non-earner, recipient is non-earner
+    ///      The transferred amount is rounded down, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderEarner_recipientNonEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: false,
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is non-earner, Hub is non-earner, recipient is earner
+    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderNonEarner_recipientEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: false,
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 3
+        });
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is earner, Hub is earner, recipient is non-earner
+    ///      The transferred amount is rounded down on source during unwrap(), recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderEarner_recipientNonEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: true,
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is non-earner, Hub is earner, recipient is earner
+    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderNonEarner_recipientEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 3
+        });
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is earner, Hub is non-earner, recipient is earner
+    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderEarner_recipientEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: false,
+            isSenderEarner_: true,
+            isRecipientEarner_: true,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 3
+        });
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is earner, Hub is earner, recipient is earner
+    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderEarner_recipientEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: true,
+            isSenderEarner_: true,
+            isRecipientEarner_: true,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 3
+        });
+    }
+
     function _testTransferMLikeTokenScenario(
         bool isHubEarner_,
         bool isSenderEarner_,

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -32,14 +32,14 @@ contract HubPortalForkTests is ForkTestBase {
         uint128 mainnetIndex_ = IContinuousIndexing(_MAINNET_M_TOKEN).currentIndex();
 
         uint256 amount_ = 1_000e6;
-        _transfer(amount_, _mHolder, _hubPortal, Chains.WORMHOLE_ARBITRUM);
+        _transfer(amount_, _mHolder, _mHolder, _hubPortal, Chains.WORMHOLE_ARBITRUM);
 
         IERC20(_MAINNET_M_TOKEN).approve(_hubPortal, amount_);
 
         assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_ = amount_ - 1);
 
         // Deliver message
-        _deliverMessageToSpoke(_arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
+        _deliverMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
 
         assertEq(IERC20(_arbitrumSpokeMToken).balanceOf(_mHolder), amount_);
         assertEq(IContinuousIndexing(_arbitrumSpokeMToken).currentIndex(), mainnetIndex_);
@@ -50,12 +50,12 @@ contract HubPortalForkTests is ForkTestBase {
     function testFork_transfer_hubNonEarner_senderNonEarner_recipientNonEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
-            isHubEarner: false,
-            isSenderEarner: false,
-            isRecipientEarner: false,
-            amount: amount_,
-            expectedHubBalance: amount_,
-            expectedRecipientBalance: amount_
+            isHubEarner_: false,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedHubBalance_: amount_,
+            expectedRecipientBalance_: amount_
         });
     }
 
@@ -64,12 +64,12 @@ contract HubPortalForkTests is ForkTestBase {
     function testFork_transfer_hubEarner_senderNonEarner_recipientNonEarner() external {
         uint256 amount_ = 15399539920;
         _testTransferScenario({
-            isHubEarner: true,
-            isSenderEarner: false,
-            isRecipientEarner: false,
-            amount: amount_,
-            expectedHubBalance: amount_ - 2,
-            expectedRecipientBalance: amount_ - 2
+            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 2
         });
     }
 
@@ -78,12 +78,12 @@ contract HubPortalForkTests is ForkTestBase {
     function testFork_transfer_hubNonEarner_senderEarner_recipientNonEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
-            isHubEarner: false,
-            isSenderEarner: true,
-            isRecipientEarner: false,
-            amount: amount_,
-            expectedHubBalance: amount_,
-            expectedRecipientBalance: amount_
+            isHubEarner_: false,
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedHubBalance_: amount_,
+            expectedRecipientBalance_: amount_
         });
     }
 
@@ -92,26 +92,26 @@ contract HubPortalForkTests is ForkTestBase {
     function testFork_transfer_hubNonEarner_senderNonEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
-            isHubEarner: false,
-            isSenderEarner: false,
-            isRecipientEarner: true,
-            amount: amount_,
-            expectedHubBalance: amount_,
-            expectedRecipientBalance: amount_ - 1
+            isHubEarner_: false,
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedHubBalance_: amount_,
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
     /// @dev Sender is earner, Hub is earner, recipient is non-earner
-    ///      The transferred amount is exact or rounded up
+    ///      The transferred amount is exact or rounded up on the source
     function testFork_transfer_hubEarner_senderEarner_recipientNonEarner() external {
         uint256 amount_ = 38962247;
         _testTransferScenario({
-            isHubEarner: true,
-            isSenderEarner: true,
-            isRecipientEarner: false,
-            amount: amount_,
-            expectedHubBalance: amount_ + 1,
-            expectedRecipientBalance: amount_ + 1
+            isHubEarner_: true,
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedHubBalance_: amount_ + 1,
+            expectedRecipientBalance_: amount_ + 1
         });
     }
 
@@ -124,12 +124,12 @@ contract HubPortalForkTests is ForkTestBase {
         // Recipient's balance is less than the amount locked in HubPortal due to the rounding
         // when transferring $M from the non-earner SpokePortal to an earner recipient.
         _testTransferScenario({
-            isHubEarner: true,
-            isSenderEarner: false,
-            isRecipientEarner: true,
-            amount: amount_,
-            expectedHubBalance: amount_ - 1,
-            expectedRecipientBalance: amount_ - 2
+            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 1,
+            expectedRecipientBalance_: amount_ - 2
         });
     }
 
@@ -138,12 +138,12 @@ contract HubPortalForkTests is ForkTestBase {
     function testFork_transfer_hubNonEarner_senderEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
-            isHubEarner: false,
-            isSenderEarner: true,
-            isRecipientEarner: true,
-            amount: amount_,
-            expectedHubBalance: amount_,
-            expectedRecipientBalance: amount_ - 1
+            isHubEarner_: false,
+            isSenderEarner_: true,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedHubBalance_: amount_,
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
@@ -152,12 +152,12 @@ contract HubPortalForkTests is ForkTestBase {
     function testFork_transfer_hubEarner_senderEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
-            isHubEarner: true,
-            isSenderEarner: true,
-            isRecipientEarner: true,
-            amount: amount_,
-            expectedHubBalance: amount_,
-            expectedRecipientBalance: amount_ - 1
+            isHubEarner_: true,
+            isSenderEarner_: true,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedHubBalance_: amount_,
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
@@ -207,17 +207,17 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     function _testTransferScenario(
-        bool isHubEarner,
-        bool isSenderEarner,
-        bool isRecipientEarner,
-        uint256 amount,
-        uint256 expectedHubBalance,
-        uint256 expectedRecipientBalance
+        bool isHubEarner_,
+        bool isSenderEarner_,
+        bool isRecipientEarner_,
+        uint256 amount_,
+        uint256 expectedHubBalance_,
+        uint256 expectedRecipientBalance_
     ) private {
         address sender_ = _mHolder;
         address recipient_ = _mHolder;
 
-        if (isRecipientEarner) {
+        if (isRecipientEarner_) {
             vm.selectFork(_mainnetForkId);
             // Propagate index
             _propagateMIndex(Chains.WORMHOLE_ARBITRUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
@@ -226,32 +226,33 @@ contract HubPortalForkTests is ForkTestBase {
             // Recipient is earning on Spoke
             _enableUserEarning(_arbitrumSpokeMToken, _arbitrumSpokeRegistrar, recipient_);
         }
-        assertEq(IMToken(_arbitrumSpokeMToken).isEarning(recipient_), isRecipientEarner);
+        assertEq(IMToken(_arbitrumSpokeMToken).isEarning(recipient_), isRecipientEarner_);
 
         // Set HubPortal and sender earning status
         vm.selectFork(_mainnetForkId);
-        if (!isHubEarner) {
+        if (!isHubEarner_) {
             _disablePortalEarning();
         }
-        if (isSenderEarner) {
+        if (isSenderEarner_) {
             // Sender is earning on Hub
             _enableUserEarning(_MAINNET_M_TOKEN, _MAINNET_REGISTRAR, sender_);
         }
-        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(_hubPortal), isHubEarner);
-        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(sender_), isSenderEarner);
+
+        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(_hubPortal), isHubEarner_);
+        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(sender_), isSenderEarner_);
 
         // Execute transfer
-        _transfer(amount, recipient_, _hubPortal, Chains.WORMHOLE_ARBITRUM);
+        _transfer(amount_, sender_, recipient_, _hubPortal, Chains.WORMHOLE_ARBITRUM);
 
         // Verify hub balance
-        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), expectedHubBalance);
+        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), expectedHubBalance_);
 
         // Deliver message
-        _deliverMessageToSpoke(_arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
+        _deliverMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
 
         // Verify recipient balance
         vm.selectFork(_arbitrumForkId);
-        assertEq(IERC20(_arbitrumSpokeMToken).balanceOf(recipient_), expectedRecipientBalance);
+        assertEq(IERC20(_arbitrumSpokeMToken).balanceOf(recipient_), expectedRecipientBalance_);
     }
 
     /* ============ transferMLikeToken ============ */

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -45,26 +45,11 @@ contract HubPortalForkTests is ForkTestBase {
         assertEq(IContinuousIndexing(_arbitrumSpokeMToken).currentIndex(), mainnetIndex_);
     }
 
-    /// @dev Sender is non-earner, Hub is non-earner, recipient is non-earner
-    ///      The transferred amount is exact, no rounding errors
-    function testFork_transfer_hubNonEarner_senderNonEarner_recipientNonEarner() external {
-        uint256 amount_ = 1_000e6;
-        _testTransferScenario({
-            isHubEarner_: false,
-            isSenderEarner_: false,
-            isRecipientEarner_: false,
-            amount_: amount_,
-            expectedHubBalance_: amount_,
-            expectedRecipientBalance_: amount_
-        });
-    }
-
-    /// @dev Sender is non-earner, Hub is earner, recipient is non-earner
+    /// @dev Sender is non-earner, recipient is non-earner
     ///      The transferred amount is rounded down on the source, recipient gets less
-    function testFork_transfer_hubEarner_senderNonEarner_recipientNonEarner() external {
-        uint256 amount_ = 15399539920;
+    function testFork_transfer_senderNonEarner_recipientNonEarner() external {
+        uint256 amount_ = 15_399_539_920;
         _testTransferScenario({
-            isHubEarner_: true,
             isSenderEarner_: false,
             isRecipientEarner_: false,
             amount_: amount_,
@@ -73,40 +58,11 @@ contract HubPortalForkTests is ForkTestBase {
         });
     }
 
-    /// @dev Sender is earner, Hub is non-earner, recipient is non-earner
-    ///      The transferred amount is exact, no rounding errors
-    function testFork_transfer_hubNonEarner_senderEarner_recipientNonEarner() external {
-        uint256 amount_ = 1_000e6;
-        _testTransferScenario({
-            isHubEarner_: false,
-            isSenderEarner_: true,
-            isRecipientEarner_: false,
-            amount_: amount_,
-            expectedHubBalance_: amount_,
-            expectedRecipientBalance_: amount_
-        });
-    }
-
-    /// @dev Sender is non-earner, Hub is non-earner, recipient is earner
-    ///      The transferred amount is rounded down on the destination, recipient gets less
-    function testFork_transfer_hubNonEarner_senderNonEarner_recipientEarner() external {
-        uint256 amount_ = 1_000e6;
-        _testTransferScenario({
-            isHubEarner_: false,
-            isSenderEarner_: false,
-            isRecipientEarner_: true,
-            amount_: amount_,
-            expectedHubBalance_: amount_,
-            expectedRecipientBalance_: amount_ - 1
-        });
-    }
-
-    /// @dev Sender is earner, Hub is earner, recipient is non-earner
+    /// @dev Sender is earner, recipient is non-earner
     ///      The transferred amount is exact or rounded up on the source
-    function testFork_transfer_hubEarner_senderEarner_recipientNonEarner() external {
-        uint256 amount_ = 38962247;
+    function testFork_transfer_senderEarner_recipientNonEarner() external {
+        uint256 amount_ = 38_962_247;
         _testTransferScenario({
-            isHubEarner_: true,
             isSenderEarner_: true,
             isRecipientEarner_: false,
             amount_: amount_,
@@ -115,16 +71,15 @@ contract HubPortalForkTests is ForkTestBase {
         });
     }
 
-    /// @dev Sender is non-earner, Hub is earner, recipient is earner
+    /// @dev Sender is non-earner, recipient is earner
     ///      The transferred amount is rounded down twice, recipient gets less
-    function testFork_transfer_hubEarner_senderNonEarner_recipientEarner() external {
+    function testFork_transfer_senderNonEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         // Amount locked in HubPortal is less than the transfer amount due to the rounding
         // when transferring $M from a non-earner sender to the earner HubPortal.
         // Recipient's balance is less than the amount locked in HubPortal due to the rounding
         // when transferring $M from the non-earner SpokePortal to an earner recipient.
         _testTransferScenario({
-            isHubEarner_: true,
             isSenderEarner_: false,
             isRecipientEarner_: true,
             amount_: amount_,
@@ -133,26 +88,11 @@ contract HubPortalForkTests is ForkTestBase {
         });
     }
 
-    /// @dev Sender is earner, Hub is non-earner, recipient is earner
+    /// @dev Sender is earner, recipient is earner
     ///      The transferred amount is rounded down on the destination, recipient gets less
-    function testFork_transfer_hubNonEarner_senderEarner_recipientEarner() external {
+    function testFork_transfer_senderEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
-            isHubEarner_: false,
-            isSenderEarner_: true,
-            isRecipientEarner_: true,
-            amount_: amount_,
-            expectedHubBalance_: amount_,
-            expectedRecipientBalance_: amount_ - 1
-        });
-    }
-
-    /// @dev Sender is earner, Hub is earner, recipient is earner
-    ///      The transferred amount is rounded down on the destination, recipient gets less
-    function testFork_transfer_hubEarner_senderEarner_recipientEarner() external {
-        uint256 amount_ = 1_000e6;
-        _testTransferScenario({
-            isHubEarner_: true,
             isSenderEarner_: true,
             isRecipientEarner_: true,
             amount_: amount_,
@@ -162,12 +102,11 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Using lower fuzz runs and depth to avoid burning through RPC requests in CI
-    /// forge-config: default.fuzz.runs = 10
-    /// forge-config: default.fuzz.depth = 2
+    /// forge-config: default.fuzz.runs = 100
+    /// forge-config: default.fuzz.depth = 20
     /// forge-config: ci.fuzz.runs = 10
     /// forge-config: ci.fuzz.depth = 2
     function testFuzz_transfer_earningStatusScenarios(
-        bool isHubEarner_,
         bool isSenderEarner_,
         bool isRecipientEarner_,
         uint256 amount_
@@ -181,13 +120,12 @@ contract HubPortalForkTests is ForkTestBase {
         uint128 index_ = IContinuousIndexing(_MAINNET_M_TOKEN).currentIndex();
 
         // Adjust expected balances based on earning scenarios
-        if (isHubEarner_) {
-            uint112 principalAmount_ = isSenderEarner_
-                ? IndexingMath.getPrincipalAmountRoundedUp(uint240(amount_), index_)
-                : IndexingMath.getPrincipalAmountRoundedDown(uint240(amount_), index_);
-            expectedHubBalance_ = IndexingMath.getPresentAmountRoundedDown(principalAmount_, index_);
-            expectedRecipientBalance_ = expectedHubBalance_;
-        }
+
+        uint112 principalAmount_ = isSenderEarner_
+            ? IndexingMath.getPrincipalAmountRoundedUp(uint240(amount_), index_)
+            : IndexingMath.getPrincipalAmountRoundedDown(uint240(amount_), index_);
+        expectedHubBalance_ = IndexingMath.getPresentAmountRoundedDown(principalAmount_, index_);
+        expectedRecipientBalance_ = expectedHubBalance_;
 
         // SpokePortal is always non-earner
         // Transferring to earner results in rounding down
@@ -197,7 +135,6 @@ contract HubPortalForkTests is ForkTestBase {
         }
 
         _testTransferScenario(
-            isHubEarner_,
             isSenderEarner_,
             isRecipientEarner_,
             amount_,
@@ -207,7 +144,6 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     function _testTransferScenario(
-        bool isHubEarner_,
         bool isSenderEarner_,
         bool isRecipientEarner_,
         uint256 amount_,
@@ -228,17 +164,12 @@ contract HubPortalForkTests is ForkTestBase {
         }
         assertEq(IMToken(_arbitrumSpokeMToken).isEarning(recipient_), isRecipientEarner_);
 
-        // Set HubPortal and sender earning status
         vm.selectFork(_mainnetForkId);
-        if (!isHubEarner_) {
-            _disablePortalEarning();
-        }
         if (isSenderEarner_) {
             // Sender is earning on Hub
             _enableUserEarning(_MAINNET_M_TOKEN, _MAINNET_REGISTRAR, sender_);
         }
 
-        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(_hubPortal), isHubEarner_);
         assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(sender_), isSenderEarner_);
 
         // Execute transfer
@@ -317,12 +248,11 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Transferring WrappedM to M
-    ///      Sender is non-earner, Hub is non-earner, recipient is non-earner
+    ///      Sender is non-earner, recipient is non-earner
     ///      The transferred amount is rounded down, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderNonEarner_recipientNonEarner() external {
+    function testFork_transferMLikeToken_wrappedM_to_M_senderNonEarner_recipientNonEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
-            isHubEarner_: false,
             isSenderEarner_: false,
             isRecipientEarner_: false,
             sender_: _wrappedMHolder,
@@ -335,66 +265,11 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Transferring WrappedM to M
-    ///      Sender is non-earner, Hub is earner, recipient is non-earner
-    ///      The transferred amount is rounded down, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderNonEarner_recipientNonEarner() external {
-        uint256 amount_ = 23_242_957_645;
-        _testTransferMLikeTokenScenario({
-            isHubEarner_: true,
-            isSenderEarner_: false,
-            isRecipientEarner_: false,
-            sender_: _wrappedMHolder,
-            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
-            destinationToken_: _arbitrumSpokeMToken,
-            amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
-        });
-    }
-
-    /// @dev Transferring WrappedM to M
-    ///      Sender is earner, Hub is non-earner, recipient is non-earner
-    ///      The transferred amount is rounded down, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderEarner_recipientNonEarner() external {
-        uint256 amount_ = 23_242_957_645;
-        _testTransferMLikeTokenScenario({
-            isHubEarner_: false,
-            isSenderEarner_: true,
-            isRecipientEarner_: false,
-            sender_: _wrappedMHolder,
-            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
-            destinationToken_: _arbitrumSpokeMToken,
-            amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
-        });
-    }
-
-    /// @dev Transferring WrappedM to M
-    ///      Sender is non-earner, Hub is non-earner, recipient is earner
-    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderNonEarner_recipientEarner() external {
-        uint256 amount_ = 23_242_957_645;
-        _testTransferMLikeTokenScenario({
-            isHubEarner_: false,
-            isSenderEarner_: false,
-            isRecipientEarner_: true,
-            sender_: _wrappedMHolder,
-            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
-            destinationToken_: _arbitrumSpokeMToken,
-            amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 3
-        });
-    }
-
-    /// @dev Transferring WrappedM to M
-    ///      Sender is earner, Hub is earner, recipient is non-earner
+    ///      Sender is earner, recipient is non-earner
     ///      The transferred amount is rounded down on source during unwrap(), recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderEarner_recipientNonEarner() external {
+    function testFork_transferMLikeToken_wrappedM_to_M_senderEarner_recipientNonEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
-            isHubEarner_: true,
             isSenderEarner_: true,
             isRecipientEarner_: false,
             sender_: _wrappedMHolder,
@@ -407,12 +282,11 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Transferring WrappedM to M
-    ///      Sender is non-earner, Hub is earner, recipient is earner
+    ///      Sender is non-earner, recipient is earner
     ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderNonEarner_recipientEarner() external {
+    function testFork_transferMLikeToken_wrappedM_to_M_senderNonEarner_recipientEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
-            isHubEarner_: true,
             isSenderEarner_: false,
             isRecipientEarner_: true,
             sender_: _wrappedMHolder,
@@ -425,12 +299,11 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Transferring WrappedM to M
-    ///      Sender is earner, Hub is non-earner, recipient is earner
+    ///      Sender is earner, recipient is earner
     ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderEarner_recipientEarner() external {
+    function testFork_transferMLikeToken_wrappedM_to_M_senderEarner_recipientEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
-            isHubEarner_: false,
             isSenderEarner_: true,
             isRecipientEarner_: true,
             sender_: _wrappedMHolder,
@@ -442,26 +315,75 @@ contract HubPortalForkTests is ForkTestBase {
         });
     }
 
-    /// @dev Transferring WrappedM to M
-    ///      Sender is earner, Hub is earner, recipient is earner
-    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
-    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderEarner_recipientEarner() external {
-        uint256 amount_ = 23_242_957_645;
+    /// @dev Transferring WrappedM to WrappedM
+    ///      Sender is non-earner, recipient is non-earner
+    ///      The transferred amount is rounded down twice, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderNonEarner_recipientNonEarner() external {
+        uint256 amount_ = 1e6;
         _testTransferMLikeTokenScenario({
-            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 1,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    /// @dev Transferring WrappedM to WrappedM
+    ///      Sender is earner, recipient is non-earner
+    ///      The transferred amount is rounded down twice, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderEarner_recipientNonEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferMLikeTokenScenario({
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 1,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    /// @dev Transferring WrappedM to WrappedM
+    ///      Sender is non-earner, recipient is earner
+    ///      The transferred amount is rounded down twice, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderNonEarner_recipientEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferMLikeTokenScenario({
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 1,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    /// @dev Transferring WrappedM to WrappedM
+    ///      Sender is earner, recipient is earner
+    ///      The transferred amount is rounded down twice, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderEarner_recipientEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferMLikeTokenScenario({
             isSenderEarner_: true,
             isRecipientEarner_: true,
             sender_: _wrappedMHolder,
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
-            destinationToken_: _arbitrumSpokeMToken,
+            destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 3
+            expectedHubBalance_: amount_ - 1,
+            expectedRecipientBalance_: amount_ - 2
         });
     }
 
     function _testTransferMLikeTokenScenario(
-        bool isHubEarner_,
         bool isSenderEarner_,
         bool isRecipientEarner_,
         address sender_,
@@ -473,28 +395,27 @@ contract HubPortalForkTests is ForkTestBase {
     ) private {
         address recipient_ = _alice;
 
-        if (isRecipientEarner_) {
-            vm.selectFork(_mainnetForkId);
-            // Propagate index
-            _propagateMIndex(Chains.WORMHOLE_ARBITRUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
+        vm.selectFork(_mainnetForkId);
+        // Propagate index
+        _propagateMIndex(Chains.WORMHOLE_ARBITRUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
 
-            vm.selectFork(_arbitrumForkId);
+        vm.selectFork(_arbitrumForkId);
+        // Wrapped M is earning on Spoke
+        _enableWrappedMEarning(_arbitrumSpokeWrappedMTokenProxy, _arbitrumSpokeRegistrar);
+        assertEq(IMToken(_arbitrumSpokeMToken).isEarning(_arbitrumSpokeWrappedMTokenProxy), true);
+
+        if (isRecipientEarner_) {
             // Recipient is earning on Spoke
             _enableUserEarning(_arbitrumSpokeMToken, _arbitrumSpokeRegistrar, recipient_);
         }
         assertEq(IMToken(_arbitrumSpokeMToken).isEarning(recipient_), isRecipientEarner_);
 
-        // Set HubPortal and sender earning status
         vm.selectFork(_mainnetForkId);
-        if (!isHubEarner_) {
-            _disablePortalEarning();
-        }
         if (isSenderEarner_) {
             // Sender is earning on Hub
             _enableUserEarning(_MAINNET_M_TOKEN, _MAINNET_REGISTRAR, sender_);
         }
 
-        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(_hubPortal), isHubEarner_);
         assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(sender_), isSenderEarner_);
 
         // Execute transfer

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -77,14 +77,14 @@ contract HubPortalForkTests is ForkTestBase {
         uint256 amount_ = 1_000e6;
         // Amount locked in HubPortal is less than the transfer amount due to the rounding
         // when transferring $M from a non-earner sender to the earner HubPortal.
-        // Recipient's balance is less than the amount locked in HubPortal due to the rounding
-        // when transferring $M from the non-earner SpokePortal to an earner recipient.
+        // Recipient's balance is less than the transfer amount due to the rounding
+        // when minting $M to an earner recipient.
         _testTransferScenario({
             isSenderEarner_: false,
             isRecipientEarner_: true,
             amount_: amount_,
             expectedHubBalance_: amount_ - 1,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
@@ -97,7 +97,7 @@ contract HubPortalForkTests is ForkTestBase {
             isRecipientEarner_: true,
             amount_: amount_,
             expectedHubBalance_: amount_,
-            expectedRecipientBalance_: amount_ - 1
+            expectedRecipientBalance_: amount_
         });
     }
 
@@ -125,12 +125,15 @@ contract HubPortalForkTests is ForkTestBase {
             ? IndexingMath.getPrincipalAmountRoundedUp(uint240(amount_), index_)
             : IndexingMath.getPrincipalAmountRoundedDown(uint240(amount_), index_);
         expectedHubBalance_ = IndexingMath.getPresentAmountRoundedDown(principalAmount_, index_);
-        expectedRecipientBalance_ = expectedHubBalance_;
+        expectedRecipientBalance_ = amount_;
 
         // SpokePortal is always non-earner
         // Transferring to earner results in rounding down
         if (isRecipientEarner_) {
-            uint112 principalAmount_ = IndexingMath.getPrincipalAmountRoundedDown(uint240(expectedHubBalance_), index_);
+            uint112 principalAmount_ = IndexingMath.getPrincipalAmountRoundedDown(
+                uint240(expectedRecipientBalance_),
+                index_
+            );
             expectedRecipientBalance_ = IndexingMath.getPresentAmountRoundedDown(principalAmount_, index_);
         }
 
@@ -231,9 +234,7 @@ contract HubPortalForkTests is ForkTestBase {
             Chains.WORMHOLE_ARBITRUM
         );
 
-        // amount is decreased due to the rounding errors when transferring M from non-earner
-        amount_ = amount_ - 1;
-        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_);
+        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_ - 1);
 
         // Wormhole delivers message
         bytes memory signedMessage_ = _signMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM);

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -36,7 +36,7 @@ contract HubPortalForkTests is ForkTestBase {
 
         IERC20(_MAINNET_M_TOKEN).approve(_hubPortal, amount_);
 
-        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_ = amount_ - 1);
+        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_ - 1);
 
         // Deliver message
         _deliverMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
@@ -46,7 +46,7 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Sender is non-earner, recipient is non-earner
-    ///      The transferred amount is rounded down on the source, recipient gets less
+    ///      The transferred amount is exact
     function testFork_transfer_senderNonEarner_recipientNonEarner() external {
         uint256 amount_ = 15_399_539_920;
         _testTransferScenario({
@@ -54,12 +54,12 @@ contract HubPortalForkTests is ForkTestBase {
             isRecipientEarner_: false,
             amount_: amount_,
             expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_
         });
     }
 
     /// @dev Sender is earner, recipient is non-earner
-    ///      The transferred amount is exact or rounded up on the source
+    ///      The transferred amount is exact
     function testFork_transfer_senderEarner_recipientNonEarner() external {
         uint256 amount_ = 38_962_247;
         _testTransferScenario({
@@ -67,12 +67,12 @@ contract HubPortalForkTests is ForkTestBase {
             isRecipientEarner_: false,
             amount_: amount_,
             expectedHubBalance_: amount_ + 1,
-            expectedRecipientBalance_: amount_ + 1
+            expectedRecipientBalance_: amount_
         });
     }
 
     /// @dev Sender is non-earner, recipient is earner
-    ///      The transferred amount is rounded down twice, recipient gets less
+    ///      The transferred amount is rounded down on the destination when minting to an earner
     function testFork_transfer_senderNonEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         // Amount locked in HubPortal is less than the transfer amount due to the rounding
@@ -89,7 +89,7 @@ contract HubPortalForkTests is ForkTestBase {
     }
 
     /// @dev Sender is earner, recipient is earner
-    ///      The transferred amount is rounded down on the destination, recipient gets less
+    ///      The transferred amount is rounded down on the destination when minting to an earner
     function testFork_transfer_senderEarner_recipientEarner() external {
         uint256 amount_ = 1_000e6;
         _testTransferScenario({
@@ -97,7 +97,7 @@ contract HubPortalForkTests is ForkTestBase {
             isRecipientEarner_: true,
             amount_: amount_,
             expectedHubBalance_: amount_,
-            expectedRecipientBalance_: amount_
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
@@ -250,7 +250,7 @@ contract HubPortalForkTests is ForkTestBase {
 
     /// @dev Transferring WrappedM to M
     ///      Sender is non-earner, recipient is non-earner
-    ///      The transferred amount is rounded down, recipient gets less
+    ///      The transferred amount is exact
     function testFork_transferMLikeToken_wrappedM_to_M_senderNonEarner_recipientNonEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
@@ -261,13 +261,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
             expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_
         });
     }
 
     /// @dev Transferring WrappedM to M
     ///      Sender is earner, recipient is non-earner
-    ///      The transferred amount is rounded down on source during unwrap(), recipient gets less
+    ///      The transferred amount is exact
     function testFork_transferMLikeToken_wrappedM_to_M_senderEarner_recipientNonEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
@@ -278,13 +278,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
             expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_
         });
     }
 
     /// @dev Transferring WrappedM to M
     ///      Sender is non-earner, recipient is earner
-    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
+    ///      The transferred amount is rounded down on the destination when minting to an earner
     function testFork_transferMLikeToken_wrappedM_to_M_senderNonEarner_recipientEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
@@ -295,13 +295,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
             expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 3
+            expectedRecipientBalance_: amount_ - 2
         });
     }
 
     /// @dev Transferring WrappedM to M
     ///      Sender is earner, recipient is earner
-    ///      The transferred amount is rounded down twice, on source and destination, recipient gets less
+    ///      The transferred amount is rounded down on the destination when minting to an earner
     function testFork_transferMLikeToken_wrappedM_to_M_senderEarner_recipientEarner() external {
         uint256 amount_ = 23_242_957_645;
         _testTransferMLikeTokenScenario({
@@ -312,13 +312,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
             expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 3
+            expectedRecipientBalance_: amount_ - 2
         });
     }
 
     /// @dev Transferring WrappedM to WrappedM
     ///      Sender is non-earner, recipient is non-earner
-    ///      The transferred amount is rounded down twice, recipient gets less
+    ///      The transferred amount is rounded down on the destination when wrapping
     function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderNonEarner_recipientNonEarner() external {
         uint256 amount_ = 1e6;
         _testTransferMLikeTokenScenario({
@@ -329,13 +329,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
             expectedHubBalance_: amount_ - 1,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
     /// @dev Transferring WrappedM to WrappedM
     ///      Sender is earner, recipient is non-earner
-    ///      The transferred amount is rounded down twice, recipient gets less
+    ///      The transferred amount is rounded down on the destination when wrapping
     function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderEarner_recipientNonEarner() external {
         uint256 amount_ = 1e6;
         _testTransferMLikeTokenScenario({
@@ -346,13 +346,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
             expectedHubBalance_: amount_ - 1,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
     /// @dev Transferring WrappedM to WrappedM
     ///      Sender is non-earner, recipient is earner
-    ///      The transferred amount is rounded down twice, recipient gets less
+    ///      The transferred amount is rounded down on the destination when wrapping
     function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderNonEarner_recipientEarner() external {
         uint256 amount_ = 1e6;
         _testTransferMLikeTokenScenario({
@@ -363,13 +363,13 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
             expectedHubBalance_: amount_ - 1,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 
     /// @dev Transferring WrappedM to WrappedM
     ///      Sender is earner, recipient is earner
-    ///      The transferred amount is rounded down twice, recipient gets less
+    ///      The transferred amount is rounded down on the destination when wrapping
     function testFork_transferMLikeToken_wrappedM_to_wrappedM_senderEarner_recipientEarner() external {
         uint256 amount_ = 1e6;
         _testTransferMLikeTokenScenario({
@@ -380,7 +380,7 @@ contract HubPortalForkTests is ForkTestBase {
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
             expectedHubBalance_: amount_ - 1,
-            expectedRecipientBalance_: amount_ - 2
+            expectedRecipientBalance_: amount_ - 1
         });
     }
 

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -290,30 +290,15 @@ contract HubPortalForkTests is ForkTestBase {
         uint128 mainnetIndex_ = IContinuousIndexing(_MAINNET_M_TOKEN).currentIndex();
         uint256 amount_ = 1e6;
 
-        // Deployer sets supported path
-        vm.prank(_DEPLOYER);
-        IPortal(_hubPortal).setSupportedBridgingPath(
+        _transferMLikeToken(
             sourceToken_,
-            Chains.WORMHOLE_ARBITRUM,
-            destinationToken_.toBytes32(),
-            true
-        );
-
-        // Recording logs for Wormhole simulation
-        vm.recordLogs();
-
-        // User approves source token and calls transferMLikeToken
-        vm.startPrank(user_);
-        IERC20(sourceToken_).approve(_hubPortal, amount_);
-        IPortal(_hubPortal).transferMLikeToken{ value: _quoteDeliveryPrice(_hubPortal, Chains.WORMHOLE_ARBITRUM) }(
+            destinationToken_,
             amount_,
-            sourceToken_,
-            Chains.WORMHOLE_ARBITRUM,
-            destinationToken_.toBytes32(),
-            user_.toBytes32(),
-            user_.toBytes32()
+            user_,
+            user_,
+            _hubPortal,
+            Chains.WORMHOLE_ARBITRUM
         );
-        vm.stopPrank();
 
         // amount is decreased due to the rounding errors when transferring M from non-earner
         amount_ = amount_ - 1;
@@ -329,6 +314,101 @@ contract HubPortalForkTests is ForkTestBase {
 
         // Spoke M index updated
         assertEq(IContinuousIndexing(_arbitrumSpokeMToken).currentIndex(), mainnetIndex_);
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is non-earner, Hub is non-earner, recipient is non-earner
+    ///      The transferred amount is rounded down, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubNonEarner_senderNonEarner_recipientNonEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: false,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    /// @dev Transferring WrappedM to M
+    ///      Sender is non-earner, Hub is earner, recipient is non-earner
+    ///      The transferred amount is rounded down, recipient gets less
+    function testFork_transferMLikeToken_wrappedM_to_M_hubEarner_senderNonEarner_recipientNonEarner() external {
+        uint256 amount_ = 23_242_957_645;
+        _testTransferMLikeTokenScenario({
+            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            sender_: _wrappedMHolder,
+            sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
+            destinationToken_: _arbitrumSpokeMToken,
+            amount_: amount_,
+            expectedHubBalance_: amount_ - 2,
+            expectedRecipientBalance_: amount_ - 2
+        });
+    }
+
+    function _testTransferMLikeTokenScenario(
+        bool isHubEarner_,
+        bool isSenderEarner_,
+        bool isRecipientEarner_,
+        address sender_,
+        address sourceToken_,
+        address destinationToken_,
+        uint256 amount_,
+        uint256 expectedHubBalance_,
+        uint256 expectedRecipientBalance_
+    ) private {
+        address recipient_ = _alice;
+
+        if (isRecipientEarner_) {
+            vm.selectFork(_mainnetForkId);
+            // Propagate index
+            _propagateMIndex(Chains.WORMHOLE_ARBITRUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
+
+            vm.selectFork(_arbitrumForkId);
+            // Recipient is earning on Spoke
+            _enableUserEarning(_arbitrumSpokeMToken, _arbitrumSpokeRegistrar, recipient_);
+        }
+        assertEq(IMToken(_arbitrumSpokeMToken).isEarning(recipient_), isRecipientEarner_);
+
+        // Set HubPortal and sender earning status
+        vm.selectFork(_mainnetForkId);
+        if (!isHubEarner_) {
+            _disablePortalEarning();
+        }
+        if (isSenderEarner_) {
+            // Sender is earning on Hub
+            _enableUserEarning(_MAINNET_M_TOKEN, _MAINNET_REGISTRAR, sender_);
+        }
+
+        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(_hubPortal), isHubEarner_);
+        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(sender_), isSenderEarner_);
+
+        // Execute transfer
+        _transferMLikeToken(
+            sourceToken_,
+            destinationToken_,
+            amount_,
+            sender_,
+            recipient_,
+            _hubPortal,
+            Chains.WORMHOLE_ARBITRUM
+        );
+
+        // Verify hub balance
+        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), expectedHubBalance_);
+
+        // Deliver message
+        _deliverMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
+
+        // Verify recipient balance
+        vm.selectFork(_arbitrumForkId);
+        assertEq(IERC20(destinationToken_).balanceOf(recipient_), expectedRecipientBalance_);
     }
 
     /* ============ sendMTokenIndex ============ */

--- a/test/fork/SpokePortalFork.t.sol
+++ b/test/fork/SpokePortalFork.t.sol
@@ -3,7 +3,8 @@
 pragma solidity 0.8.26;
 
 import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
-import { IContinuousIndexing } from "../../lib/protocol/src/interfaces/IContinuousIndexing.sol";
+import { IMToken } from "../../lib/protocol/src/interfaces/IMToken.sol";
+import { IndexingMath } from "../../lib/common/src/libs/IndexingMath.sol";
 
 import { Chains } from "../../script/config/Chains.sol";
 import { IPortal } from "../../src/interfaces/IPortal.sol";
@@ -16,16 +17,13 @@ import { ForkTestBase } from "./ForkTestBase.t.sol";
 contract SpokePortalForkTests is ForkTestBase {
     using TypeConverter for *;
 
-    uint256 internal _amount;
+    uint256 internal _amount = 1000e6;
     uint128 internal _mainnetIndex;
 
     /* ============ transfer ============ */
 
     function testFork_transferToHubPortal() external {
-        _beforeTest();
-
-        vm.prank(_DEPLOYER);
-        IPortal(_arbitrumSpokePortal).setDestinationMToken(Chains.WORMHOLE_ETHEREUM, _MAINNET_M_TOKEN.toBytes32());
+        _transferFromHub(_amount + 1);
 
         vm.startPrank(_mHolder);
 
@@ -58,26 +56,18 @@ contract SpokePortalForkTests is ForkTestBase {
     }
 
     function testFork_transferBetweenSpokePortals() external {
-        _beforeTest();
+        _transferFromHub(_amount + 1);
 
-        vm.prank(_DEPLOYER);
-        IPortal(_arbitrumSpokePortal).setDestinationMToken(Chains.WORMHOLE_OPTIMISM, _optimismSpokeMToken.toBytes32());
+        vm.selectFork(_optimismForkId);
+        assertEq(IMToken(_optimismSpokeMToken).currentIndex(), _EXP_SCALED_ONE);
+
+        vm.selectFork(_arbitrumForkId);
+        uint128 arbitrumIndex = IMToken(_arbitrumSpokeMToken).currentIndex();
+        assertGt(arbitrumIndex, _EXP_SCALED_ONE);
+
+        _transfer(_amount, _mHolder, _mHolder, _arbitrumSpokePortal, Chains.WORMHOLE_OPTIMISM);
 
         vm.startPrank(_mHolder);
-
-        IERC20(_arbitrumSpokeMToken).approve(_arbitrumSpokePortal, _amount);
-
-        // Then, transfer M tokens to the other Spoke chain.
-        _transfer(
-            _arbitrumSpokePortal,
-            Chains.WORMHOLE_OPTIMISM,
-            _amount,
-            _toUniversalAddress(_mHolder),
-            _toUniversalAddress(_mHolder),
-            _quoteDeliveryPrice(_optimismSpokePortal, Chains.WORMHOLE_OPTIMISM)
-        );
-
-        vm.stopPrank();
 
         assertEq(IERC20(_arbitrumSpokeMToken).balanceOf(_mHolder), 0);
 
@@ -88,33 +78,226 @@ contract SpokePortalForkTests is ForkTestBase {
         _deliverMessage(_OPTIMISM_WORMHOLE_RELAYER, spokeSignedMessage_);
 
         assertEq(IERC20(_optimismSpokeMToken).balanceOf(_mHolder), _amount);
-        assertEq(IContinuousIndexing(_optimismSpokeMToken).currentIndex(), _mainnetIndex);
+        assertEq(IMToken(_optimismSpokeMToken).currentIndex(), arbitrumIndex);
+    }
+
+    /// @dev Sender is non-earner, Hub is non-earner, recipient is non-earner
+    ///      The transferred amount is exact, no rounding errors
+    function testFork_transferToHub_hubNonEarner_senderNonEarner_recipientNonEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferToHubScenario({
+            isHubEarner_: false,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_
+        });
+    }
+
+    /// @dev Sender is non-earner, Hub is earner, recipient is non-earner
+    ///      The transferred amount is exact, no rounding errors
+    function testFork_transferToHub_hubEarner_senderNonEarner_recipientNonEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferToHubScenario({
+            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_
+        });
+    }
+
+    /// @dev Sender is earner, Hub is non-earner, recipient is non-earner
+    ///      The transferred amount is exact, no rounding errors
+    function testFork_transferToHub_hubNonEarner_senderEarner_recipientNonEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferToHubScenario({
+            isHubEarner_: false,
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_
+        });
+    }
+
+    /// @dev Sender is non-earner, Hub is non-earner, recipient is earner
+    ///      The transferred amount is rounded down on the destination, recipient gets less
+    function testFork_transferToHub_hubNonEarner_senderNonEarner_recipientEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferToHubScenario({
+            isHubEarner_: false,
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_ - 1
+        });
+    }
+
+    /// @dev Sender is earner, Hub is earner, recipient is non-earner
+    ///      The transferred amount is exact, no rounding errors
+    function testFork_transferToHub_hubEarner_senderEarner_recipientNonEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferToHubScenario({
+            isHubEarner_: true,
+            isSenderEarner_: true,
+            isRecipientEarner_: false,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_
+        });
+    }
+
+    /// @dev Sender is non-earner, Hub is earner, recipient is earner
+    ///      The transferred amount is exact or rounded up
+    function testFork_transferToHub_hubEarner_senderNonEarner_recipientEarner() external {
+        uint256 amount_ = 45_269_208;
+        _testTransferToHubScenario({
+            isHubEarner_: true,
+            isSenderEarner_: false,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_ + 1
+        });
+    }
+
+    /// @dev Sender is earner, Hub is non-earner, recipient is earner
+    ///      The transferred amount is rounded down, recipient gets less
+    function testFork_transferToHub_hubNonEarner_senderEarner_recipientEarner() external {
+        uint256 amount_ = 1e6;
+        _testTransferToHubScenario({
+            isHubEarner_: false,
+            isSenderEarner_: true,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_ - 1
+        });
+    }
+
+    /// @dev Sender is earner, Hub is earner, recipient is earner
+    ///      The transferred amount is exact or rounded up
+    function testFork_transferToHub_hubEarner_senderEarner_recipientEarner() external {
+        uint256 amount_ = 45_269_208;
+        _testTransferToHubScenario({
+            isHubEarner_: true,
+            isSenderEarner_: true,
+            isRecipientEarner_: true,
+            amount_: amount_,
+            expectedRecipientBalance_: amount_ + 1
+        });
+    }
+
+    /// @dev Using lower fuzz runs and depth to avoid burning through RPC requests in CI
+    /// forge-config: default.fuzz.runs = 10
+    /// forge-config: default.fuzz.depth = 2
+    /// forge-config: ci.fuzz.runs = 10
+    /// forge-config: ci.fuzz.depth = 2
+    function testFuzz_transferToHub_earningStatusScenarios(
+        bool isHubEarner_,
+        bool isSenderEarner_,
+        bool isRecipientEarner_,
+        uint256 amount_
+    ) external {
+        vm.assume(amount_ > 1e6 && amount_ <= 100_000e6);
+
+        uint256 expectedRecipientBalance_ = amount_;
+
+        vm.selectFork(_mainnetForkId);
+        uint128 index_ = IMToken(_MAINNET_M_TOKEN).currentIndex();
+
+        // Adjust expected balance based on earning scenarios
+        if (isRecipientEarner_) {
+            uint112 principalAmount_ = isHubEarner_
+                ? IndexingMath.getPrincipalAmountRoundedUp(uint240(amount_), index_)
+                : IndexingMath.getPrincipalAmountRoundedDown(uint240(amount_), index_);
+            expectedRecipientBalance_ = IndexingMath.getPresentAmountRoundedDown(principalAmount_, index_);
+        }
+
+        _testTransferToHubScenario(
+            isHubEarner_,
+            isSenderEarner_,
+            isRecipientEarner_,
+            amount_,
+            expectedRecipientBalance_
+        );
+    }
+
+    function _testTransferToHubScenario(
+        bool isHubEarner_,
+        bool isSenderEarner_,
+        bool isRecipientEarner_,
+        uint256 amount_,
+        uint256 expectedRecipientBalance_
+    ) private {
+        address sender_ = _mHolder;
+        address recipient_ = _alice;
+
+        // seed sender's balance on Spoke by transferring from Hub first
+        _transferFromHub(1_000_000e6);
+
+        // sender has enough $M on spoke to perform transfer
+        vm.selectFork(_arbitrumForkId);
+        assertGt(IERC20(_arbitrumSpokeMToken).balanceOf(sender_), amount_);
+
+        // Hub has enough $M locked to perform transfer
+        vm.selectFork(_arbitrumForkId);
+        assertGt(IERC20(_arbitrumSpokeMToken).balanceOf(sender_), amount_);
+
+        if (isSenderEarner_) {
+            vm.selectFork(_arbitrumForkId);
+            // Sender is earning on Spoke
+            _enableUserEarning(_arbitrumSpokeMToken, _arbitrumSpokeRegistrar, sender_);
+        }
+
+        vm.selectFork(_arbitrumForkId);
+        assertEq(IMToken(_arbitrumSpokeMToken).isEarning(sender_), isSenderEarner_);
+
+        vm.selectFork(_mainnetForkId);
+        if (!isHubEarner_) {
+            _disablePortalEarning();
+        }
+        if (isRecipientEarner_) {
+            // Recipient is earning on Hub
+            _enableUserEarning(_MAINNET_M_TOKEN, _MAINNET_REGISTRAR, recipient_);
+        }
+
+        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(_hubPortal), isHubEarner_);
+        assertEq(IMToken(_MAINNET_M_TOKEN).isEarning(recipient_), isRecipientEarner_);
+
+        vm.selectFork(_arbitrumForkId);
+        // Execute transfer
+        _transfer(amount_, sender_, recipient_, _arbitrumSpokePortal, Chains.WORMHOLE_ETHEREUM);
+
+        // Deliver message
+        _deliverMessage(_arbitrumSpokeGuardian, Chains.WORMHOLE_ARBITRUM, _mainnetForkId, _MAINNET_WORMHOLE_RELAYER);
+
+        // Verify recipient balance
+        vm.selectFork(_mainnetForkId);
+        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(recipient_), expectedRecipientBalance_);
     }
 
     /* ============ transferMLikeToken ============ */
 
     /// @dev From $M on Spoke to $M on Hub
     function testFork_transferMLikeToken_M_to_M() external {
-        _beforeTest();
+        _transferFromHub(_amount + 1);
         _transferMLikeTokenToHub(_arbitrumSpokeMToken, _MAINNET_M_TOKEN, _mHolder);
     }
 
     /// @dev From $M on Spoke to wrapped $M on Hub
     function testFork_transferMLikeToken_M_to_wrappedM() external {
-        _beforeTest();
+        _transferFromHub(_amount + 1);
         _transferMLikeTokenToHub(_arbitrumSpokeMToken, _MAINNET_WRAPPED_M_TOKEN, _mHolder);
     }
 
     /// @dev From wrapped $M on Spoke to $M on Hub
     function testFork_transferMLikeToken_wrappedM_to_M() external {
-        _beforeTest();
+        _transferFromHub(_amount + 1);
         _amount = _wrapSpokeM(_mHolder, _amount);
         _transferMLikeTokenToHub(_arbitrumSpokeWrappedMTokenProxy, _MAINNET_M_TOKEN, _mHolder);
     }
 
     /// @dev From wrapped $M on Spoke to wrapped $M on Hub
     function testFork_transferMLikeToken_wrappedM_to_wrappedM() external {
-        _beforeTest();
+        _transferFromHub(_amount + 1);
         _amount = _wrapSpokeM(_mHolder, _amount);
         _transferMLikeTokenToHub(_arbitrumSpokeWrappedMTokenProxy, _MAINNET_WRAPPED_M_TOKEN, _mHolder);
     }
@@ -128,15 +311,6 @@ contract SpokePortalForkTests is ForkTestBase {
     }
 
     function _transferMLikeTokenToHub(address sourceToken_, address destinationToken_, address user_) private {
-        // Deployer sets supported path
-        vm.prank(_DEPLOYER);
-        IPortal(_arbitrumSpokePortal).setSupportedBridgingPath(
-            sourceToken_,
-            Chains.WORMHOLE_ETHEREUM,
-            destinationToken_.toBytes32(),
-            true
-        );
-
         // User approves source token and calls transferMLikeToken
         vm.startPrank(user_);
         IERC20(sourceToken_).approve(_arbitrumSpokePortal, _amount);
@@ -167,42 +341,12 @@ contract SpokePortalForkTests is ForkTestBase {
         assertEq(IERC20(destinationToken_).balanceOf(user_), balanceOfBefore_ + _amount);
     }
 
-    function _beforeTest() internal {
-        _amount = 1_000e6;
-
-        // First, transfer M tokens to the Spoke chain.
+    /// @dev Setup Spoke with $M from Hub
+    function _transferFromHub(uint256 amount_) internal {
         vm.selectFork(_mainnetForkId);
+        _transfer(amount_, _mHolder, _mHolder, _hubPortal, Chains.WORMHOLE_ARBITRUM);
 
-        vm.prank(_DEPLOYER);
-        IPortal(_hubPortal).setDestinationMToken(Chains.WORMHOLE_ARBITRUM, _arbitrumSpokeMToken.toBytes32());
-
-        _mainnetIndex = IContinuousIndexing(_MAINNET_M_TOKEN).currentIndex();
-
-        vm.startPrank(_mHolder);
-        vm.recordLogs();
-
-        IERC20(_MAINNET_M_TOKEN).approve(_hubPortal, _amount);
-
-        _transfer(
-            _hubPortal,
-            Chains.WORMHOLE_ARBITRUM,
-            _amount,
-            _toUniversalAddress(_mHolder),
-            _toUniversalAddress(_mHolder),
-            _quoteDeliveryPrice(_hubPortal, Chains.WORMHOLE_ARBITRUM)
-        );
-
-        vm.stopPrank();
-
-        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), _amount = _amount - 1);
-
-        bytes memory hubSignedMessage_ = _signMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM);
-
-        vm.selectFork(_arbitrumForkId);
-
-        _deliverMessage(_ARBITRUM_WORMHOLE_RELAYER, hubSignedMessage_);
-
-        assertEq(IERC20(_arbitrumSpokeMToken).balanceOf(_mHolder), _amount);
-        assertEq(IContinuousIndexing(_arbitrumSpokeMToken).currentIndex(), _mainnetIndex);
+        // Deliver message
+        _deliverMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM, _arbitrumForkId, _ARBITRUM_WORMHOLE_RELAYER);
     }
 }

--- a/test/fork/SpokeVaultFork.t.sol
+++ b/test/fork/SpokeVaultFork.t.sol
@@ -40,11 +40,13 @@ contract SpokeVaultForkTests is ForkTestBase {
 
         vm.selectFork(_mainnetForkId);
 
+        // Advance time to simulate yield earning by HubPortal
+        vm.warp(block.timestamp + 10 seconds);
+
         uint256 balanceOfBefore_ = IERC20(_MAINNET_M_TOKEN).balanceOf(_MAINNET_VAULT);
 
         _deliverMessage(_MAINNET_WORMHOLE_RELAYER, spokeSignedMessage_);
 
-        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), 0);
         assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_MAINNET_VAULT), balanceOfBefore_ + _amount);
     }
 


### PR DESCRIPTION
### Motivation

`HubPortal` is an earner and the transfer amount is rounded down when a non-earner transfers $M to it. E.g. a user transfers `1 $M`, but the amount locked in `HubPortal` and transferred cross-chain is `0.999999 $M` due to rounding down

### Proposed changes:

- transfer the **_exact_** amount specified by the sender rather than the **_actual_** amount received by `HubPortal` to improve user experience. E.g. if a user transfers `1 $M`, `0.999999 $M` will be locked in `HubPortal`, but `1 $M` will be minted on Spoke chain.
- add more fork tests

### Assumptions:
- Since `HubPortal` is an earner the "deficit" will be covered by the yield. If earning for `HubPortal` is to be stopped, the transferring of exact amount must be re-evaluated.
- $M extensions registered in Portals MUST NOT have fee-on-transfer logic as it can lead to an exploit when the actual amount transferred to `HubPortal` is significantly less than the exact amount.

### Note:
When transferring to an earner on a Spoke the amount still will be rounded down due to [rounding down ]([url](https://github.com/m0-foundation/protocol/blob/main/src/MToken.sol#L260))in $M `mint` function