### PR TITLE
fix: prevent potential Portal exploit due to fee-on-transfer in approved extensions

### DIFF
--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -489,7 +489,7 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
     function _currentIndex() internal view virtual returns (uint128) {}
 
     /// @dev Returns the maximum rounding error that can occur when transferring M tokens to the Portal
-    function _getMaxRoundingError() private view returns (uint256 maxRoundingError_) {
-        maxRoundingError_ = _currentIndex() / IndexingMath.EXP_SCALED_ONE + 1;
+    function _getMaxRoundingError() private view returns (uint256) {
+        return _currentIndex() / IndexingMath.EXP_SCALED_ONE + 1;
     }
 }


### PR DESCRIPTION
### Motivation

In PR #58 Portals were upgraded to send the **_exact_** amount specified by the sender ignoring potential rounding errors when transferring $M between non-earners and earners. While the change is safe when transferring $M, it introduces an exploit possibility if an approved $M extension is compromised or upgraded to charge fee on transfer. For example, a registered extension $M token was upgraded to introduce 20% fee-on-transfer. Now when a user transfers 1 Extension token it gets unwrapped to 0.8 $M, but since the Portal transfer the exact amount rather than the actual amount, 1 $M is minted on a Spoke.

### Proposed Changes

If the difference between the _exact_ and _actual_ amounts exceeds the maximum acceptable value (`currentIndex/EXP_SCALD_ONE + 1`,  which is 2 wei), the Portal will transfer the _actual_ amount, not _exact_