### PR TITLE
feat: executor relaying for Solana

### DIFF
--- a/src/ExecutorEntryPoint.sol
+++ b/src/ExecutorEntryPoint.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.26;
+
+import { IERC20 } from "../lib/common/src/interfaces/IERC20.sol";
+import { INttManager } from "../lib/native-token-transfers/evm/src/interfaces/INttManager.sol";
+import { IPortal } from "./interfaces/IPortal.sol";
+import { IHubPortal } from "./interfaces/IHubPortal.sol";
+import "./interfaces/IExecutorEntryPoint.sol";
+import "./external/IExecutor.sol";
+import "./external/ExecutorMessages.sol";
+
+string constant executorEntryPointVersion = "ExecutorEntryPoint-0.0.1";
+
+/// @title ExecutorEntryPoint
+/// @notice The ExecutorEntryPoint contract is a shim contract that initiates
+///         an M NTT transfer using the executor for relaying.
+contract ExecutorEntryPoint is IExecutorEntryPoint {
+    uint16 public immutable chainId;
+    IExecutor public immutable executor;
+    IPortal public immutable portal;
+
+    string public constant VERSION = executorEntryPointVersion;
+
+    constructor(uint16 _chainId, address _executor, address _portal) {
+        assert(_chainId != 0);
+        assert(_executor != address(0));
+        assert(_portal != address(0));
+        chainId = _chainId;
+        executor = IExecutor(_executor);
+        portal = IPortal(_portal);
+    }
+
+    // ==================== External Interface ===============================================
+
+    /// @inheritdoc IExecutorEntryPoint
+    function transferMLikeToken(
+        uint256 amount,
+        address sourceToken,
+        uint16 destinationChainId,
+        bytes32 destinationToken,
+        bytes32 recipient,
+        bytes32 refundAddress,
+        ExecutorArgs calldata executorArgs
+    ) external payable returns (bytes32 messageId) {
+        // Validate input
+        if (!portal.supportedBridgingPath(sourceToken, destinationChainId, destinationToken)) {
+            revert IPortal.UnsupportedBridgingPath(sourceToken, destinationChainId, destinationToken);
+        }
+
+        // Custody the tokens in this contract and approve Portal to spend them.
+        // TODO do we need to handle rounding b/w M earners and non-earners?
+        amount = _custodyTokens(sourceToken, amount);
+
+        // Initiate the transfer.
+        IERC20(sourceToken).approve(address(portal), amount);
+        uint64 sequence = portal.transferMLikeToken{ value: msg.value - executorArgs.value }(
+            amount,
+            sourceToken,
+            destinationChainId,
+            destinationToken,
+            recipient,
+            refundAddress
+        );
+        messageId = bytes32(uint256(sequence));
+
+        // Generate the executor request event.
+        _requestExecution(destinationChainId, messageId, executorArgs);
+    }
+
+    /// @inheritdoc IExecutorEntryPoint
+    function sendMTokenIndex(
+        uint16 destinationChainId,
+        bytes32 refundAddress,
+        ExecutorArgs calldata executorArgs
+    ) external payable returns (bytes32 messageId) {
+        messageId = IHubPortal(address(portal)).sendMTokenIndex{ value: msg.value - executorArgs.value }(
+            destinationChainId,
+            refundAddress
+        );
+
+        // Generate the executor request event.
+        _requestExecution(destinationChainId, messageId, executorArgs);
+    }
+
+    /// @inheritdoc IExecutorEntryPoint
+    function sendEarnersMerkleRoot(
+        bytes32 refundAddress,
+        ExecutorArgs calldata executorArgs
+    ) external payable returns (bytes32 messageId) {
+        messageId = IHubPortal(address(portal)).sendEarnersMerkleRoot{ value: msg.value - executorArgs.value }(
+            refundAddress
+        );
+
+        // Generate the executor request event.
+        // Chain ID is always Solana (1) for this message.
+        _requestExecution(1, messageId, executorArgs);
+    }
+
+    // ==================== Internal Functions ==============================================
+
+    function _requestExecution(
+        uint16 destinationChainId,
+        bytes32 messageId,
+        ExecutorArgs calldata executorArgs
+    ) internal {
+        // Generate the executor event.
+        executor.requestExecution{ value: executorArgs.value }(
+            destinationChainId,
+            INttManager(address(portal)).getPeer(destinationChainId).peerAddress,
+            executorArgs.refundAddress,
+            executorArgs.signedQuote,
+            ExecutorMessages.makeNTTv1Request(chainId, bytes32(uint256(uint160(address(portal)))), messageId),
+            executorArgs.instructions
+        );
+
+        // Refund any excess value.
+        uint256 currentBalance = address(this).balance;
+        if (currentBalance > 0) {
+            (bool refundSuccessful, ) = payable(executorArgs.refundAddress).call{ value: currentBalance }("");
+            if (!refundSuccessful) {
+                revert RefundFailed(currentBalance);
+            }
+        }
+    }
+
+    function _custodyTokens(address token, uint256 amount) internal returns (uint256) {
+        // query own token balance before transfer
+        uint256 balanceBefore = _getBalance(token);
+
+        // deposit tokens
+        IERC20(token).transferFrom(msg.sender, address(this), amount);
+
+        // return the balance difference
+        return _getBalance(token) - balanceBefore;
+    }
+
+    function _getBalance(address token) internal view returns (uint256 balance) {
+        // fetch the specified token balance for this contract
+        (, bytes memory queriedBalance) = token.staticcall(
+            abi.encodeWithSelector(IERC20.balanceOf.selector, address(this))
+        );
+        balance = abi.decode(queriedBalance, (uint256));
+    }
+}

--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -21,9 +21,6 @@ import { TypeConverter } from "./libs/TypeConverter.sol";
 contract HubPortal is IHubPortal, Portal {
     using TypeConverter for address;
 
-    uint16 internal constant _SOLANA_WORMHOLE_CHAIN_ID = 1;
-    bytes32 internal constant _SOLANA_EARNER_LIST = bytes32("solana-earners");
-
     /* ============ Variables ============ */
 
     /// @inheritdoc IHubPortal

--- a/src/external/ExecutorMessages.sol
+++ b/src/external/ExecutorMessages.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.26;
+
+library ExecutorMessages {
+    bytes4 private constant REQ_MM = "ERM1";
+    bytes4 private constant REQ_VAA_V1 = "ERV1";
+    bytes4 private constant REQ_NTT_V1 = "ERN1";
+    bytes4 private constant REQ_CCTP_V1 = "ERC1";
+
+    /// @notice Payload length will not fit in a uint32.
+    /// @dev Selector: 492f620d.
+    error PayloadTooLarge();
+
+    /// @notice Encodes a modular messaging request payload.
+    /// @param srcChain The source chain for the message (usually this chain).
+    /// @param srcAddr The source address for the message.
+    /// @param sequence The sequence number returned by `endpoint.sendMessage`.
+    /// @param payload The full payload, the keccak of which was sent to `endpoint.sendMessage`.
+    /// @return bytes The encoded request.
+    function makeMMRequest(
+        uint16 srcChain,
+        address srcAddr,
+        uint64 sequence,
+        bytes memory payload
+    ) internal pure returns (bytes memory) {
+        if (payload.length > type(uint32).max) {
+            revert PayloadTooLarge();
+        }
+        return
+            abi.encodePacked(
+                REQ_MM,
+                srcChain,
+                bytes32(uint256(uint160(srcAddr))),
+                sequence,
+                uint32(payload.length),
+                payload
+            );
+    }
+
+    /// @notice Encodes a version 1 VAA request payload.
+    /// @param emitterChain The emitter chain from the VAA.
+    /// @param emitterAddress The emitter address from the VAA.
+    /// @param sequence The sequence number from the VAA.
+    /// @return bytes The encoded request.
+    function makeVAAv1Request(
+        uint16 emitterChain,
+        bytes32 emitterAddress,
+        uint64 sequence
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(REQ_VAA_V1, emitterChain, emitterAddress, sequence);
+    }
+
+    /// @notice Encodes a version 1 NTT request payload.
+    /// @param srcChain The source chain for the NTT transfer.
+    /// @param srcManager The source manager for the NTT transfer.
+    /// @param messageId The manager message id for the NTT transfer.
+    /// @return bytes The encoded request.
+    function makeNTTv1Request(
+        uint16 srcChain,
+        bytes32 srcManager,
+        bytes32 messageId
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(REQ_NTT_V1, srcChain, srcManager, messageId);
+    }
+
+    /// @notice Encodes a version 1 CCTP request payload.
+    /// @param sourceDomain The source chain for the CCTP transfer.
+    /// @param nonce The nonce of the CCTP transfer.
+    /// @return bytes The encoded request.
+    function makeCCTPv1Request(uint32 sourceDomain, uint64 nonce) internal pure returns (bytes memory) {
+        return abi.encodePacked(REQ_CCTP_V1, sourceDomain, nonce);
+    }
+}

--- a/src/external/IExecutor.sol
+++ b/src/external/IExecutor.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.26;
+
+interface IExecutor {
+    struct SignedQuoteHeader {
+        bytes4 prefix;
+        address quoterAddress;
+        bytes32 payeeAddress;
+        uint16 srcChain;
+        uint16 dstChain;
+        uint64 expiryTime;
+    }
+
+    event RequestForExecution(
+        address indexed quoterAddress,
+        uint256 amtPaid,
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        bytes signedQuote,
+        bytes requestBytes,
+        bytes relayInstructions
+    );
+
+    function requestExecution(
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        bytes calldata signedQuote,
+        bytes calldata requestBytes,
+        bytes calldata relayInstructions
+    ) external payable;
+}

--- a/src/interfaces/IExecutorEntryPoint.sol
+++ b/src/interfaces/IExecutorEntryPoint.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity 0.8.26;
+
+struct ExecutorArgs {
+    // The msg value to be passed into the Executor.
+    uint256 value;
+    // The refund address used by the Executor.
+    address refundAddress;
+    // The signed quote to be passed into the Executor.
+    bytes signedQuote;
+    // The relay instructions to be passed into the Executor.
+    bytes instructions;
+}
+
+interface IExecutorEntryPoint {
+    /// @notice Error when the refund to the sender fails.
+    /// @dev Selector 0x2ca23714.
+    /// @param refundAmount The refund amount.
+    error RefundFailed(uint256 refundAmount);
+
+    /// @notice Peer cannot have zero decimals.
+    error InvalidPeerDecimals();
+
+    /// @notice Transfer a given amount to a recipient on a given chain using the Executor for relaying.
+    /// @param amount The amount to transfer.
+    /// @param sourceToken M or an M extension that is supported by the Portal.
+    /// @param destinationChainId The Wormhole chain ID for the destination.
+    /// @param destinationToken The token address on the destination chain (M or Wrapped M).
+    /// @param recipient The recipient address on the destination chain.
+    /// @param executorArgs The arguments to be passed into the Executor.
+    /// @return messageId The resulting message ID of the transfer
+    function transferMLikeToken(
+        uint256 amount,
+        address sourceToken,
+        uint16 destinationChainId,
+        bytes32 destinationToken,
+        bytes32 recipient,
+        bytes32 refundAddress,
+        ExecutorArgs calldata executorArgs
+    ) external payable returns (bytes32 messageId);
+
+    /// @notice Send the M token index to a given chain using the Executor for relaying.
+    /// @param destinationChainId The Wormhole chain ID for the destination.
+    /// @param refundAddress The Wormhole address to refund excess gas to.
+    /// @param executorArgs The arguments to be passed into the Executor.
+    /// @return messageId The resulting message ID of the index send.
+    function sendMTokenIndex(
+        uint16 destinationChainId,
+        bytes32 refundAddress,
+        ExecutorArgs calldata executorArgs
+    ) external payable returns (bytes32 messageId);
+
+    /// @notice Send the earners Merkle root to Solana using the Executor for relaying.
+    /// @param refundAddress The Wormhole address to refund excess gas to.
+    /// @param executorArgs The arguments to be passed into the Executor.
+    /// @return messageId The resulting message ID of the Merkle root send.
+    function sendEarnersMerkleRoot(
+        bytes32 refundAddress,
+        ExecutorArgs calldata executorArgs
+    ) external payable returns (bytes32 messageId);
+}

--- a/test/unit/HubPortal.t.sol
+++ b/test/unit/HubPortal.t.sol
@@ -27,6 +27,8 @@ contract HubPortalTests is UnitTestBase {
     bytes32 internal constant _SOLANA_EARNER_LIST = bytes32("solana-earners");
     bytes32 internal constant _SOLANA_EARN_MANAGER_LIST = bytes32("solana-earn-managers");
 
+    TransceiverStructs.TransceiverInstruction internal _executorTransceiverInstruction;
+
     MockHubMToken internal _mToken;
     MockWrappedMToken internal _wrappedMToken;
     bytes32 internal _remoteMToken;
@@ -38,6 +40,10 @@ contract HubPortalTests is UnitTestBase {
 
     bytes32 _solanaPeer = bytes32("solana-peer");
     bytes32 _solanaToken = bytes32("solana-token");
+
+    constructor() UnitTestBase() {
+        _executorTransceiverInstruction = TransceiverStructs.TransceiverInstruction({ index: 0, payload: hex"01" });
+    }
 
     function setUp() external {
         _mToken = new MockHubMToken();
@@ -252,7 +258,7 @@ contract HubPortalTests is UnitTestBase {
                 _transceiver.sendMessage,
                 (
                     _SOLANA_WORMHOLE_CHAIN_ID,
-                    _emptyTransceiverInstruction,
+                    _executorTransceiverInstruction,
                     TransceiverStructs.encodeNttManagerMessage(message_),
                     _solanaPeer,
                     refundAddress_
@@ -392,7 +398,7 @@ contract HubPortalTests is UnitTestBase {
                 _transceiver.sendMessage,
                 (
                     _SOLANA_WORMHOLE_CHAIN_ID,
-                    _emptyTransceiverInstruction,
+                    _executorTransceiverInstruction,
                     TransceiverStructs.encodeNttManagerMessage(message_),
                     _solanaPeer,
                     refundAddress_


### PR DESCRIPTION
This PR adds an overlay contract on the Portal to allow sending messages to Solana using Wormhole's Executor framework for relaying instead of the Standard Relayer. This is required to support custom message passing to Solana without the use of a Special Relayer. While the current version is supported by a Special Relayer on Solana mainnet, there will not be support for other SVM chains. Additionally, the complexity of messages to support increases with the Solana V2 upgrades, which add bridging directly to M extensions.

Wormhole has provided information on this integration and built what they call a "shim" contract they call [NttWithExecutor](https://sepolia.etherscan.io/address/0x54DD7080aE169DD923fE56d0C4f814a0a17B8f41#code) to request Executor relaying for NTT messages. The `ExecutorEntryPoint` in this PR follows a similar pattern, but tailored to the M Portal functions.

A problem I ran into during this implementation is that we hardcode an empty TransceiverInstruction set in the messages that the Portal sends to the Transceiver, but this relaying option requires a different instruction. I have added it as a constant and only use it for Solana. However, it may be better to refactor to allow using the Executor relayer between other chains.

As has become the norm, I believe I'm running into contract size issues, even with the minor change I made. It may be solvable by experimenting with different optimizer runs or finding some unused code path to remove, but I haven't gotten that far.