### PR TITLE
feat: pass transceiver instructions as a parameter

### DIFF
--- a/script/tasks/TaskBase.sol
+++ b/script/tasks/TaskBase.sol
@@ -14,11 +14,17 @@ import { ISpokeVault } from "../../src/interfaces/ISpokeVault.sol";
 import { ScriptBase } from "../ScriptBase.sol";
 
 contract TaskBase is ScriptBase {
+    bytes public constant RELAYER_TRANSCEIVER_INSTRUCTIONS = new bytes(1);
+    bytes public constant EXECUTOR_TRANSCEIVER_INSTRUCTIONS = hex"01000101"; // equivalent to: [TransceiverInstruction({ index: 0, payload: 0x01 })]
+
     function _quoteDeliveryPrice(
         address hubPortal_,
         uint16 destinationChainId_
     ) internal view returns (uint256 deliveryPrice_) {
-        (, deliveryPrice_) = IManagerBase(hubPortal_).quoteDeliveryPrice(destinationChainId_, new bytes(1));
+        (, deliveryPrice_) = IManagerBase(hubPortal_).quoteDeliveryPrice(
+            destinationChainId_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
+        );
     }
 
     function _sendMTokenIndex(
@@ -27,7 +33,12 @@ contract TaskBase is ScriptBase {
         bytes32 refundAddress_,
         uint256 value_
     ) internal returns (bytes32 messageId_) {
-        return IHubPortal(hubPortal_).sendMTokenIndex{ value: value_ }(destinationChainId_, refundAddress_);
+        return
+            IHubPortal(hubPortal_).sendMTokenIndex{ value: value_ }(
+                destinationChainId_,
+                refundAddress_,
+                RELAYER_TRANSCEIVER_INSTRUCTIONS
+            );
     }
 
     function _sendRegistrarKey(
@@ -37,7 +48,13 @@ contract TaskBase is ScriptBase {
         bytes32 refundAddress_,
         uint256 value_
     ) internal returns (bytes32 messageId_) {
-        return IHubPortal(hubPortal_).sendRegistrarKey{ value: value_ }(destinationChainId_, key_, refundAddress_);
+        return
+            IHubPortal(hubPortal_).sendRegistrarKey{ value: value_ }(
+                destinationChainId_,
+                key_,
+                refundAddress_,
+                RELAYER_TRANSCEIVER_INSTRUCTIONS
+            );
     }
 
     function _sendRegistrarListStatus(
@@ -53,7 +70,8 @@ contract TaskBase is ScriptBase {
                 destinationChainId_,
                 listName_,
                 account_,
-                refundAddress_
+                refundAddress_,
+                RELAYER_TRANSCEIVER_INSTRUCTIONS
             );
     }
 
@@ -72,7 +90,7 @@ contract TaskBase is ScriptBase {
                 recipient_,
                 refundAddress_,
                 false,
-                new bytes(1)
+                RELAYER_TRANSCEIVER_INSTRUCTIONS
             );
     }
 

--- a/script/tasks/TransferMLikeToken.s.sol
+++ b/script/tasks/TransferMLikeToken.s.sol
@@ -41,7 +41,8 @@ contract TransferMLikeToken is TaskBase {
             destinationChainId_,
             destinationToken_,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
 
         vm.stopBroadcast();

--- a/src/ExecutorEntryPoint.sol
+++ b/src/ExecutorEntryPoint.sol
@@ -40,7 +40,8 @@ contract ExecutorEntryPoint is IExecutorEntryPoint {
         bytes32 destinationToken,
         bytes32 recipient,
         bytes32 refundAddress,
-        ExecutorArgs calldata executorArgs
+        ExecutorArgs calldata executorArgs,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId) {
         // Validate input
         if (!portal.supportedBridgingPath(sourceToken, destinationChainId, destinationToken)) {
@@ -59,7 +60,8 @@ contract ExecutorEntryPoint is IExecutorEntryPoint {
             destinationChainId,
             destinationToken,
             recipient,
-            refundAddress
+            refundAddress,
+            transceiverInstructions
         );
         messageId = bytes32(uint256(sequence));
 
@@ -71,11 +73,13 @@ contract ExecutorEntryPoint is IExecutorEntryPoint {
     function sendMTokenIndex(
         uint16 destinationChainId,
         bytes32 refundAddress,
-        ExecutorArgs calldata executorArgs
+        ExecutorArgs calldata executorArgs,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId) {
         messageId = IHubPortal(address(portal)).sendMTokenIndex{ value: msg.value - executorArgs.value }(
             destinationChainId,
-            refundAddress
+            refundAddress,
+            transceiverInstructions
         );
 
         // Generate the executor request event.
@@ -85,10 +89,12 @@ contract ExecutorEntryPoint is IExecutorEntryPoint {
     /// @inheritdoc IExecutorEntryPoint
     function sendEarnersMerkleRoot(
         bytes32 refundAddress,
-        ExecutorArgs calldata executorArgs
+        ExecutorArgs calldata executorArgs,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId) {
         messageId = IHubPortal(address(portal)).sendEarnersMerkleRoot{ value: msg.value - executorArgs.value }(
-            refundAddress
+            refundAddress,
+            transceiverInstructions
         );
 
         // Generate the executor request event.

--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -51,15 +51,17 @@ contract HubPortal is IHubPortal, Portal {
     /// @inheritdoc IHubPortal
     function sendMTokenIndex(
         uint16 destinationChainId_,
-        bytes32 refundAddress_
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
     ) external payable returns (bytes32 messageId_) {
         uint128 index_ = _currentIndex();
         messageId_ = destinationChainId_ == _SOLANA_WORMHOLE_CHAIN_ID
-            ? _sendMTokenIndexToSolana(index_, refundAddress_)
+            ? _sendMTokenIndexToSolana(index_, refundAddress_, transceiverInstructions_)
             : _sendCustomMessage(
                 destinationChainId_,
                 refundAddress_,
-                PayloadEncoder.encodeIndex(index_, destinationChainId_)
+                PayloadEncoder.encodeIndex(index_, destinationChainId_),
+                transceiverInstructions_
             );
 
         emit MTokenIndexSent(destinationChainId_, messageId_, index_);
@@ -69,7 +71,8 @@ contract HubPortal is IHubPortal, Portal {
     function sendRegistrarKey(
         uint16 destinationChainId_,
         bytes32 key_,
-        bytes32 refundAddress_
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
     ) external payable returns (bytes32 messageId_) {
         // Sending Registrar key to Solana is not supported at this time.
         // To propagate earners to Solana call `sendEarnersMerkleRoot`.
@@ -77,7 +80,7 @@ contract HubPortal is IHubPortal, Portal {
 
         bytes32 value_ = IRegistrarLike(registrar).get(key_);
         bytes memory payload_ = PayloadEncoder.encodeKey(key_, value_, destinationChainId_);
-        messageId_ = _sendCustomMessage(destinationChainId_, refundAddress_, payload_);
+        messageId_ = _sendCustomMessage(destinationChainId_, refundAddress_, payload_, transceiverInstructions_);
 
         emit RegistrarKeySent(destinationChainId_, messageId_, key_, value_);
     }
@@ -87,7 +90,8 @@ contract HubPortal is IHubPortal, Portal {
         uint16 destinationChainId_,
         bytes32 listName_,
         address account_,
-        bytes32 refundAddress_
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
     ) external payable returns (bytes32 messageId_) {
         // Sending Registrar key status to Solana is not supported at this time.
         // To propagate earners to Solana call `sendEarnersMerkleRoot`.
@@ -95,13 +99,16 @@ contract HubPortal is IHubPortal, Portal {
 
         bool status_ = IRegistrarLike(registrar).listContains(listName_, account_);
         bytes memory payload_ = PayloadEncoder.encodeListUpdate(listName_, account_, status_, destinationChainId_);
-        messageId_ = _sendCustomMessage(destinationChainId_, refundAddress_, payload_);
+        messageId_ = _sendCustomMessage(destinationChainId_, refundAddress_, payload_, transceiverInstructions_);
 
         emit RegistrarListStatusSent(destinationChainId_, messageId_, listName_, account_, status_);
     }
 
     /// @inheritdoc IHubPortal
-    function sendEarnersMerkleRoot(bytes32 refundAddress_) external payable returns (bytes32 messageId_) {
+    function sendEarnersMerkleRoot(
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
+    ) external payable returns (bytes32 messageId_) {
         bytes32 destinationToken_ = destinationMToken[_SOLANA_WORMHOLE_CHAIN_ID];
         bytes32 earnersMerkleRoot_ = IMerkleTreeBuilder(merkleTreeBuilder).getRoot(_SOLANA_EARNER_LIST);
 
@@ -118,7 +125,8 @@ contract HubPortal is IHubPortal, Portal {
             destinationToken_,
             refundAddress_, // recipient doesn't matter since transfer amount is 0
             refundAddress_,
-            additionalPayload_
+            additionalPayload_,
+            transceiverInstructions_
         );
 
         emit EarnersMerkleRootSent(messageId_, earnersMerkleRoot_);
@@ -172,7 +180,8 @@ contract HubPortal is IHubPortal, Portal {
     function _sendCustomMessage(
         uint16 destinationChainId_,
         bytes32 refundAddress_,
-        bytes memory payload_
+        bytes memory payload_,
+        bytes memory transceiverInstructions_
     ) private returns (bytes32 messageId_) {
         if (refundAddress_ == bytes32(0)) revert InvalidRefundAddress();
 
@@ -182,13 +191,17 @@ contract HubPortal is IHubPortal, Portal {
             payload_
         );
 
-        _sendMessage(destinationChainId_, refundAddress_, message_);
+        _sendMessage(destinationChainId_, refundAddress_, message_, transceiverInstructions_);
 
         messageId_ = TransceiverStructs.nttManagerMessageDigest(chainId, message_);
     }
 
     /// @dev A workaround to send M Token Index to Solana as an additional payload with zero token transfer
-    function _sendMTokenIndexToSolana(uint128 index_, bytes32 refundAddress_) private returns (bytes32 messageId_) {
+    function _sendMTokenIndexToSolana(
+        uint128 index_,
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
+    ) private returns (bytes32 messageId_) {
         bytes32 destinationToken_ = destinationMToken[_SOLANA_WORMHOLE_CHAIN_ID];
         bytes memory additionalPayload_ = PayloadEncoder.encodeAdditionalPayload(index_, destinationToken_);
 
@@ -199,7 +212,8 @@ contract HubPortal is IHubPortal, Portal {
             destinationToken_,
             refundAddress_, // recipient doesn't matter since transfer amount is 0
             refundAddress_,
-            additionalPayload_
+            additionalPayload_,
+            transceiverInstructions_
         );
     }
 

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -26,11 +26,6 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
     using TrimmedAmountLib for *;
     using SafeCall for address;
 
-    /// @dev Use standard WormholeTransceiver with relaying enabled by default
-    ///      for Solana, we need to use the Executor with relaying disabled.
-    bytes public constant DEFAULT_TRANSCEIVER_INSTRUCTIONS = new bytes(1);
-    bytes public constant EXECUTOR_TRANSCEIVER_INSTRUCTIONS = hex"01000101"; // equivalent to: [TransceiverInstruction({ index: 0, payload: 0x01 })]
-
     uint16 internal constant _SOLANA_WORMHOLE_CHAIN_ID = 1;
     bytes32 internal constant _SOLANA_EARNER_LIST = bytes32("solana-earners");
 
@@ -108,7 +103,8 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         uint16 destinationChainId_,
         bytes32 destinationToken_,
         bytes32 recipient_,
-        bytes32 refundAddress_
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
     ) external payable nonReentrant whenNotPaused returns (uint64 sequence_) {
         if (!supportedBridgingPath[sourceToken_][destinationChainId_][destinationToken_]) {
             revert UnsupportedBridgingPath(sourceToken_, destinationChainId_, destinationToken_);
@@ -120,7 +116,8 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
             destinationChainId_,
             destinationToken_,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            transceiverInstructions_
         );
     }
 
@@ -141,7 +138,7 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         bytes32 recipient_,
         bytes32 refundAddress_,
         bool, // shouldQueue_
-        bytes memory // transceiverInstructions_
+        bytes memory transceiverInstructions_
     ) internal override returns (uint64 sequence_) {
         sequence_ = _transferMLikeToken(
             amount_,
@@ -149,19 +146,21 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
             destinationChainId_,
             destinationMToken[destinationChainId_], // M Token on destination
             recipient_,
-            refundAddress_
+            refundAddress_,
+            transceiverInstructions_
         );
     }
 
     /**
      * @dev    Transfers M or Wrapped M Token to the destination chain.
-     * @param  amount_             The amount of tokens to transfer.
-     * @param  sourceToken_        The address of the token (M or Wrapped M) on the source chain.
-     * @param  destinationChainId_ The Wormhole destination chain ID.
-     * @param  destinationToken_   The address of the token (M or Wrapped M) on the destination chain.
-     * @param  recipient_          The account to receive tokens.
-     * @param  refundAddress_      The address to receive excess native gas on the destination chain.
-     * @return sequence_           The message sequence.
+     * @param  amount_                  The amount of tokens to transfer.
+     * @param  sourceToken_             The address of the token (M or Wrapped M) on the source chain.
+     * @param  destinationChainId_      The Wormhole destination chain ID.
+     * @param  destinationToken_        The address of the token (M or Wrapped M) on the destination chain.
+     * @param  recipient_               The account to receive tokens.
+     * @param  refundAddress_           The address to receive excess native gas on the destination chain.
+     * @param  transceiverInstructions_ The transceiver specific instructions for quoting and sending.
+     * @return sequence_                The message sequence.
      */
     function _transferMLikeToken(
         uint256 amount_,
@@ -169,7 +168,8 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         uint16 destinationChainId_,
         bytes32 destinationToken_,
         bytes32 recipient_,
-        bytes32 refundAddress_
+        bytes32 refundAddress_,
+        bytes memory transceiverInstructions_
     ) private returns (uint64 sequence_) {
         _verifyTransferAmount(amount_);
 
@@ -212,14 +212,18 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         // In case of Hub, do nothing, as tokens are already transferred.
         _burnOrLock(actualAmount_);
 
+        // Prevent stack too deep error
+        bytes32 destinationToken = destinationToken_;
+
         (sequence_, ) = _transferNativeToken(
             amount_,
             sourceToken_,
             destinationChainId_,
-            destinationToken_,
+            destinationToken,
             recipient_,
             refundAddress_,
-            PayloadEncoder.encodeAdditionalPayload(_currentIndex(), destinationToken_)
+            PayloadEncoder.encodeAdditionalPayload(_currentIndex(), destinationToken),
+            transceiverInstructions_
         );
     }
 
@@ -227,14 +231,15 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
      * @dev    Transfers M or Wrapped M Token to the destination chain.
      * @dev    adapted from NttManager `_transfer` function.
      * @dev    https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol#L521
-     * @param  amount_             The amount of tokens to transfer.
-     * @param  sourceToken_        The address of the token (M or Wrapped M) on the source chain.
-     * @param  destinationChainId_ The Wormhole destination chain ID.
-     * @param  destinationToken_   The address of the token (M or Wrapped M) on the destination chain.
-     * @param  recipient_          The account to receive tokens.
-     * @param  refundAddress_      The address to receive excess native gas on the destination chain.
-     * @param  additionalPayload_  The additional payload to sent with tokens transfer.
-     * @return sequence_           The message sequence.
+     * @param  amount_                  The amount of tokens to transfer.
+     * @param  sourceToken_             The address of the token (M or Wrapped M) on the source chain.
+     * @param  destinationChainId_      The Wormhole destination chain ID.
+     * @param  destinationToken_        The address of the token (M or Wrapped M) on the destination chain.
+     * @param  recipient_               The account to receive tokens.
+     * @param  refundAddress_           The address to receive excess native gas on the destination chain.
+     * @param  additionalPayload_       The additional payload to sent with tokens transfer.
+     * @param  transceiverInstructions_ The transceiver specific instructions for quoting and sending.
+     * @return sequence_                The message sequence.
      */
     function _transferNativeToken(
         uint256 amount_,
@@ -243,7 +248,8 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         bytes32 destinationToken_,
         bytes32 recipient_,
         bytes32 refundAddress_,
-        bytes memory additionalPayload_
+        bytes memory additionalPayload_,
+        bytes memory transceiverInstructions_
     ) internal returns (uint64 sequence_, bytes32 messageId_) {
         sequence_ = _useMessageSequence();
         TransceiverStructs.NttManagerMessage memory message_;
@@ -256,7 +262,12 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
             sequence_
         );
 
-        uint256 totalPriceQuote_ = _sendMessage(destinationChainId_, refundAddress_, message_);
+        uint256 totalPriceQuote_ = _sendMessage(
+            destinationChainId_,
+            refundAddress_,
+            message_,
+            transceiverInstructions_
+        );
 
         // prevent stack too deep
         uint256 transferAmount_ = amount_;
@@ -323,15 +334,17 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
     /**
      * @dev    Sends a generic message to the destination chain.
      *         The implementation is adapted from `NttManager` `_transfer` function.
-     * @param  destinationChainId_ The Wormhole destination chain ID.
-     * @param  refundAddress_      The address to receive excess native gas on the destination chain.
-     * @param  message_            The message to send.
-     * @return totalPriceQuote_    The price to deliver the message to the destination chain.
+     * @param  destinationChainId_      The Wormhole destination chain ID.
+     * @param  refundAddress_           The address to receive excess native gas on the destination chain.
+     * @param  message_                 The message to send.
+     * @param  transceiverInstructions_ The transceiver specific instructions for quoting and sending.
+     * @return totalPriceQuote_         The price to deliver the message to the destination chain.
      */
     function _sendMessage(
         uint16 destinationChainId_,
         bytes32 refundAddress_,
-        TransceiverStructs.NttManagerMessage memory message_
+        TransceiverStructs.NttManagerMessage memory message_,
+        bytes memory transceiverInstructions_
     ) internal returns (uint256 totalPriceQuote_) {
         _verifyIfChainForked();
 
@@ -341,9 +354,7 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
 
         (enabledTransceivers_, instructions_, priceQuotes_, totalPriceQuote_) = _prepareForTransfer(
             destinationChainId_,
-            destinationChainId_ == _SOLANA_WORMHOLE_CHAIN_ID
-                ? EXECUTOR_TRANSCEIVER_INSTRUCTIONS
-                : DEFAULT_TRANSCEIVER_INSTRUCTIONS
+            transceiverInstructions_
         );
 
         // send a message

--- a/src/interfaces/IExecutorEntryPoint.sol
+++ b/src/interfaces/IExecutorEntryPoint.sol
@@ -28,6 +28,7 @@ interface IExecutorEntryPoint {
     /// @param destinationToken The token address on the destination chain (M or Wrapped M).
     /// @param recipient The recipient address on the destination chain.
     /// @param executorArgs The arguments to be passed into the Executor.
+    /// @param transceiverInstructions The transceiver specific instructions for quoting and sending.
     /// @return messageId The resulting message ID of the transfer
     function transferMLikeToken(
         uint256 amount,
@@ -36,26 +37,31 @@ interface IExecutorEntryPoint {
         bytes32 destinationToken,
         bytes32 recipient,
         bytes32 refundAddress,
-        ExecutorArgs calldata executorArgs
+        ExecutorArgs calldata executorArgs,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId);
 
     /// @notice Send the M token index to a given chain using the Executor for relaying.
     /// @param destinationChainId The Wormhole chain ID for the destination.
     /// @param refundAddress The Wormhole address to refund excess gas to.
     /// @param executorArgs The arguments to be passed into the Executor.
+    /// @param transceiverInstructions The transceiver specific instructions for quoting and sending.
     /// @return messageId The resulting message ID of the index send.
     function sendMTokenIndex(
         uint16 destinationChainId,
         bytes32 refundAddress,
-        ExecutorArgs calldata executorArgs
+        ExecutorArgs calldata executorArgs,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId);
 
     /// @notice Send the earners Merkle root to Solana using the Executor for relaying.
     /// @param refundAddress The Wormhole address to refund excess gas to.
     /// @param executorArgs The arguments to be passed into the Executor.
+    /// @param transceiverInstructions The transceiver specific instructions for quoting and sending.
     /// @return messageId The resulting message ID of the Merkle root send.
     function sendEarnersMerkleRoot(
         bytes32 refundAddress,
-        ExecutorArgs calldata executorArgs
+        ExecutorArgs calldata executorArgs,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId);
 }

--- a/src/interfaces/IHubPortal.sol
+++ b/src/interfaces/IHubPortal.sol
@@ -101,51 +101,61 @@ interface IHubPortal is IPortal {
 
     /**
      * @notice Sends the M token index to the destination chain.
-     * @param  destinationChainId The Wormhole destination chain ID.
-     * @param  refundAddress      The refund address to receive excess native gas.
-     * @return messageId          The ID uniquely identifying the message.
+     * @param  destinationChainId      The Wormhole destination chain ID.
+     * @param  refundAddress           The refund address to receive excess native gas.
+     * @param  transceiverInstructions The transceiver specific instructions for quoting and sending.
+     * @return messageId               The ID uniquely identifying the message.
      */
     function sendMTokenIndex(
         uint16 destinationChainId,
-        bytes32 refundAddress
+        bytes32 refundAddress,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sends the Registrar key to the destination chain.
      * @dev    Not supported for Solana.
-     * @param  destinationChainId The Wormhole destination chain ID.
-     * @param  key                The key to dispatch.
-     * @param  refundAddress      The refund address to receive excess native gas.
-     * @return messageId          The ID uniquely identifying the message
+     * @param  destinationChainId      The Wormhole destination chain ID.
+     * @param  key                     The key to dispatch.
+     * @param  refundAddress           The refund address to receive excess native gas.
+     * @param  transceiverInstructions The transceiver specific instructions for quoting and sending.
+     * @return messageId               The ID uniquely identifying the message
      */
     function sendRegistrarKey(
         uint16 destinationChainId,
         bytes32 key,
-        bytes32 refundAddress
+        bytes32 refundAddress,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sends the Registrar list status for an account to the destination chain.
      * @dev    Not supported for Solana.
-     * @param  destinationChainId The Wormhole destination chain ID.
-     * @param  listName           The name of the list.
-     * @param  account            The account.
-     * @param  refundAddress      The refund address to receive excess native gas.
-     * @return messageId          The ID uniquely identifying the message.
+     * @param  destinationChainId      The Wormhole destination chain ID.
+     * @param  listName                The name of the list.
+     * @param  account                 The account.
+     * @param  refundAddress           The refund address to receive excess native gas.
+     * @param  transceiverInstructions The transceiver specific instructions for quoting and sending.
+     * @return messageId               The ID uniquely identifying the message.
      */
     function sendRegistrarListStatus(
         uint16 destinationChainId,
         bytes32 listName,
         address account,
-        bytes32 refundAddress
+        bytes32 refundAddress,
+        bytes memory transceiverInstructions
     ) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sends earners Merkle root to Solana.
-     * @param  refundAddress The refund address to receive excess native gas.
-     * @return messageId     The ID uniquely identifying the message.
+     * @param  refundAddress           The refund address to receive excess native gas.
+     * @param  transceiverInstructions The transceiver specific instructions for quoting and sending.
+     * @return messageId               The ID uniquely identifying the message.
      */
-    function sendEarnersMerkleRoot(bytes32 refundAddress) external payable returns (bytes32 messageId);
+    function sendEarnersMerkleRoot(
+        bytes32 refundAddress,
+        bytes memory transceiverInstructions
+    ) external payable returns (bytes32 messageId);
 
     /**
      * @notice Sets Merkle Tree Builder contract.

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -162,13 +162,14 @@ interface IPortal {
     /**
      * @notice Transfers M or Wrapped M Token to the destination chain.
      * @dev    If wrapping on the destination fails, the recipient will receive $M token.
-     * @param  amount             The amount of tokens to transfer.
-     * @param  sourceToken        The address of the token (M or Wrapped M) on the source chain.
-     * @param  destinationChainId The Wormhole destination chain ID.
-     * @param  destinationToken   The address of the token (M or Wrapped M) on the destination chain.
-     * @param  recipient          The account to receive tokens.
-     * @param  refundAddress      The address to receive excess native gas on the destination chain.
-     * @return sequence           The message sequence.
+     * @param  amount                  The amount of tokens to transfer.
+     * @param  sourceToken             The address of the token (M or Wrapped M) on the source chain.
+     * @param  destinationChainId      The Wormhole destination chain ID.
+     * @param  destinationToken        The address of the token (M or Wrapped M) on the destination chain.
+     * @param  recipient               The account to receive tokens.
+     * @param  refundAddress           The address to receive excess native gas on the destination chain.
+     * @param  transceiverInstructions The transceiver specific instructions for quoting and sending.
+     * @return sequence                The message sequence.
      */
     function transferMLikeToken(
         uint256 amount,
@@ -176,6 +177,7 @@ interface IPortal {
         uint16 destinationChainId,
         bytes32 destinationToken,
         bytes32 recipient,
-        bytes32 refundAddress
+        bytes32 refundAddress,
+        bytes memory transceiverInstructions
     ) external payable returns (uint64 sequence);
 }

--- a/test/fork/ForkTestBase.t.sol
+++ b/test/fork/ForkTestBase.t.sol
@@ -391,7 +391,8 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
             destinationChainId_,
             destinationToken_.toBytes32(),
             recipient_.toBytes32(),
-            recipient_.toBytes32()
+            recipient_.toBytes32(),
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
         vm.stopPrank();
     }

--- a/test/fork/SpokePortalFork.t.sol
+++ b/test/fork/SpokePortalFork.t.sol
@@ -364,7 +364,8 @@ contract SpokePortalForkTests is ForkTestBase {
             Chains.WORMHOLE_ETHEREUM,
             destinationToken_.toBytes32(),
             user_.toBytes32(),
-            user_.toBytes32()
+            user_.toBytes32(),
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
         vm.stopPrank();
 

--- a/test/unit/HubPortal.t.sol
+++ b/test/unit/HubPortal.t.sol
@@ -191,7 +191,7 @@ contract HubPortalTests is UnitTestBase {
         vm.expectRevert(INttManager.InvalidRefundAddress.selector);
 
         vm.prank(_alice);
-        _portal.sendMTokenIndex(_REMOTE_CHAIN_ID, address(0).toBytes32());
+        _portal.sendMTokenIndex(_REMOTE_CHAIN_ID, address(0).toBytes32(), RELAYER_TRANSCEIVER_INSTRUCTIONS);
     }
 
     function test_sendMTokenIndex() external {
@@ -228,7 +228,7 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.MTokenIndexSent(_REMOTE_CHAIN_ID, messageId_, index_);
 
         vm.prank(_alice);
-        _portal.sendMTokenIndex{ value: fee_ }(_REMOTE_CHAIN_ID, refundAddress_);
+        _portal.sendMTokenIndex{ value: fee_ }(_REMOTE_CHAIN_ID, refundAddress_, RELAYER_TRANSCEIVER_INSTRUCTIONS);
     }
 
     function test_sendMTokenIndex_solana() external {
@@ -270,7 +270,11 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.MTokenIndexSent(_SOLANA_WORMHOLE_CHAIN_ID, messageId_, index_);
 
         vm.prank(_alice);
-        _portal.sendMTokenIndex{ value: fee_ }(_SOLANA_WORMHOLE_CHAIN_ID, refundAddress_);
+        _portal.sendMTokenIndex{ value: fee_ }(
+            _SOLANA_WORMHOLE_CHAIN_ID,
+            refundAddress_,
+            EXECUTOR_TRANSCEIVER_INSTRUCTIONS
+        );
     }
 
     /* ============ sendRegistrarKey ============ */
@@ -279,7 +283,12 @@ contract HubPortalTests is UnitTestBase {
         vm.expectRevert(INttManager.InvalidRefundAddress.selector);
 
         vm.prank(_alice);
-        _portal.sendRegistrarKey(_REMOTE_CHAIN_ID, bytes32("key"), address(0).toBytes32());
+        _portal.sendRegistrarKey(
+            _REMOTE_CHAIN_ID,
+            bytes32("key"),
+            address(0).toBytes32(),
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
+        );
     }
 
     function test_sendRegistrarKey() external {
@@ -315,7 +324,12 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.RegistrarKeySent(_REMOTE_CHAIN_ID, messageId_, key_, value_);
 
         vm.prank(_alice);
-        _portal.sendRegistrarKey{ value: fee_ }(_REMOTE_CHAIN_ID, key_, refundAddress_);
+        _portal.sendRegistrarKey{ value: fee_ }(
+            _REMOTE_CHAIN_ID,
+            key_,
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
+        );
     }
 
     /* ============ sendRegistrarListStatus ============ */
@@ -324,7 +338,13 @@ contract HubPortalTests is UnitTestBase {
         vm.expectRevert(INttManager.InvalidRefundAddress.selector);
 
         vm.prank(_alice);
-        _portal.sendRegistrarListStatus(_REMOTE_CHAIN_ID, bytes32("listName"), _bob, address(0).toBytes32());
+        _portal.sendRegistrarListStatus(
+            _REMOTE_CHAIN_ID,
+            bytes32("listName"),
+            _bob,
+            address(0).toBytes32(),
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
+        );
     }
 
     function test_sendRegistrarListStatus() external {
@@ -361,7 +381,13 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.RegistrarListStatusSent(_REMOTE_CHAIN_ID, messageId_, listName_, account_, status_);
 
         vm.prank(_alice);
-        _portal.sendRegistrarListStatus{ value: fee_ }(_REMOTE_CHAIN_ID, listName_, account_, refundAddress_);
+        _portal.sendRegistrarListStatus{ value: fee_ }(
+            _REMOTE_CHAIN_ID,
+            listName_,
+            account_,
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
+        );
     }
 
     /* ============ sendMerkleRoots ============ */
@@ -410,7 +436,7 @@ contract HubPortalTests is UnitTestBase {
         emit IHubPortal.EarnersMerkleRootSent(messageId_, earnersMerkleRoot_);
 
         vm.prank(_alice);
-        _portal.sendEarnersMerkleRoot(refundAddress_);
+        _portal.sendEarnersMerkleRoot(refundAddress_, EXECUTOR_TRANSCEIVER_INSTRUCTIONS);
     }
 
     /* ============ transfer ============ */
@@ -491,7 +517,8 @@ contract HubPortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
 
         assertEq(_mToken.balanceOf(_alice), 0);
@@ -557,7 +584,8 @@ contract HubPortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
 
         assertEq(_mToken.balanceOf(_alice), 0);

--- a/test/unit/Portal.t.sol
+++ b/test/unit/Portal.t.sol
@@ -234,7 +234,8 @@ contract PortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
     }
 
@@ -250,7 +251,8 @@ contract PortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
     }
 
@@ -266,7 +268,8 @@ contract PortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
     }
 
@@ -291,7 +294,8 @@ contract PortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
     }
 

--- a/test/unit/SpokePortal.t.sol
+++ b/test/unit/SpokePortal.t.sol
@@ -230,7 +230,8 @@ contract SpokePortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
 
         assertEq(_mToken.balanceOf(_alice), 0);
@@ -298,7 +299,8 @@ contract SpokePortalTests is UnitTestBase {
             _REMOTE_CHAIN_ID,
             _remoteWrappedMToken,
             recipient_,
-            refundAddress_
+            refundAddress_,
+            RELAYER_TRANSCEIVER_INSTRUCTIONS
         );
 
         assertEq(_mToken.balanceOf(_alice), 0);

--- a/test/unit/UnitTestBase.t.sol
+++ b/test/unit/UnitTestBase.t.sol
@@ -20,6 +20,9 @@ contract UnitTestBase is Test {
     using TypeConverter for *;
     using TrimmedAmountLib for *;
 
+    bytes public constant RELAYER_TRANSCEIVER_INSTRUCTIONS = new bytes(1);
+    bytes public constant EXECUTOR_TRANSCEIVER_INSTRUCTIONS = hex"01000101"; // equivalent to: [TransceiverInstruction({ index: 0, payload: 0x01 })]
+
     uint16 internal constant _LOCAL_CHAIN_ID = 2;
     uint16 internal constant _REMOTE_CHAIN_ID = 3;
     bytes32 internal constant _PEER = "peer";


### PR DESCRIPTION
### Description 

Add `bytes transceiverInstructions` parameter to `transferMLikeToken`, `sendMTokenIndex`, `sendRegistrarKey`, `sendRegistrarListStatus`, and `sendEarnersMerkleRoot` functions to allow using Wormhole Executor, instead of default Relayer