### PR TITLE
feat: update Portal to use SwapFacility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 	path = lib/wrapped-m-token
 	url = git@github.com:m0-foundation/wrapped-m-token.git
 	branch = spoke
+[submodule "lib/uniswap-v4-periphery"]
+	path = lib/uniswap-v4-periphery
+	url = git@github.com:Uniswap/v4-periphery.git

--- a/script/ScriptBase.sol
+++ b/script/ScriptBase.sol
@@ -32,6 +32,9 @@ contract ScriptBase is Script {
 
     uint8 internal constant _M_TOKEN_DECIMALS = 6;
 
+    // Same address for all EVM chains
+    address internal constant _SWAP_FACILITY = 0xB6807116b3B1B321a390594e31ECD6e0076f6278;
+
     // Same address across all supported mainnet and testnets networks.
     address internal constant _CREATE_X_FACTORY = 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed;
 

--- a/script/config/WormholeConfig.sol
+++ b/script/config/WormholeConfig.sol
@@ -21,7 +21,7 @@ library WormholeConfig {
     uint8 internal constant FINALIZED_CONSISTENCY_LEVEL = 1;
 
     /// @dev Gas limit to process a message on the destination
-    uint256 internal constant GAS_LIMIT = 300_000;
+    uint256 internal constant GAS_LIMIT = 400_000;
     address internal constant SPECIAL_RELAYER = 0x63BE47835c7D66c4aA5B2C688Dc6ed9771c94C74;
 
     /// @dev Wormhole Chain Ids https://wormhole.com/docs/build/reference/chain-ids/

--- a/script/deploy/DeployBase.sol
+++ b/script/deploy/DeployBase.sol
@@ -49,6 +49,7 @@ contract DeployBase is ScriptBase {
      * @dev    Deploys Hub Portal and Wormhole Transceiver.
      * @param  deployer_          The address of the deployer.
      * @param  wormholeChainId_   The Wormhole Chain Id where Hub is deployed.
+     * @param  swapFacility_      The address of the swap facility.
      * @param  hubConfig_         The configuration to deploy Hub Portal.
      * @param  transceiverConfig_ The configuration to deploy Wormhole Transceiver.
      * @return hubPortal_         The address of the deployed Hub Portal.
@@ -57,10 +58,11 @@ contract DeployBase is ScriptBase {
     function _deployHubComponents(
         address deployer_,
         uint16 wormholeChainId_,
+        address swapFacility_,
         HubDeployConfig memory hubConfig_,
         WormholeTransceiverConfig memory transceiverConfig_
     ) internal returns (address hubPortal_, address hubTransceiver_) {
-        hubPortal_ = _deployHubPortal(deployer_, wormholeChainId_, hubConfig_, _PORTAL_CONTRACT_NAME);
+        hubPortal_ = _deployHubPortal(deployer_, wormholeChainId_, swapFacility_, hubConfig_, _PORTAL_CONTRACT_NAME);
         hubTransceiver_ = _deployWormholeTransceiver(
             deployer_,
             transceiverConfig_,
@@ -75,6 +77,7 @@ contract DeployBase is ScriptBase {
      * @dev    Deploys Hub Portal and Wormhole Transceiver for Noble.
      * @param  deployer_          The address of the deployer.
      * @param  wormholeChainId_   The Wormhole Chain Id where Hub is deployed.
+     * @param  swapFacility_      The address of the swap facility.
      * @param  hubConfig_         The configuration to deploy Hub Portal.
      * @param  transceiverConfig_ The configuration to deploy Wormhole Transceiver.
      * @return hubPortal_         The address of the deployed Noble Portal.
@@ -83,10 +86,17 @@ contract DeployBase is ScriptBase {
     function _deployNobleHubComponents(
         address deployer_,
         uint16 wormholeChainId_,
+        address swapFacility_,
         HubDeployConfig memory hubConfig_,
         WormholeTransceiverConfig memory transceiverConfig_
     ) internal returns (address hubPortal_, address hubTransceiver_) {
-        hubPortal_ = _deployHubPortal(deployer_, wormholeChainId_, hubConfig_, _NOBLE_PORTAL_CONTRACT_NAME);
+        hubPortal_ = _deployHubPortal(
+            deployer_,
+            wormholeChainId_,
+            swapFacility_,
+            hubConfig_,
+            _NOBLE_PORTAL_CONTRACT_NAME
+        );
         hubTransceiver_ = _deployWormholeTransceiver(
             deployer_,
             transceiverConfig_,
@@ -101,6 +111,7 @@ contract DeployBase is ScriptBase {
      * @dev    Deploys Spoke M Token, Registrar, Portal and Wormhole Transceiver.
      * @param  deployer_          The address of the deployer.
      * @param  wormholeChainId_   The Wormhole Chain Id where Spoke is deployed.
+     * @param  swapFacility_      The address of the swap facility.
      * @param  transceiverConfig_ The configuration to deploy Wormhole Transceiver.
      * @param  burnNonces_        The function to burn nonces.
      * @return spokePortal_       The address of the deployed Spoke Portal.
@@ -111,6 +122,7 @@ contract DeployBase is ScriptBase {
     function _deploySpokeComponents(
         address deployer_,
         uint16 wormholeChainId_,
+        address swapFacility_,
         WormholeTransceiverConfig memory transceiverConfig_,
         function(address, uint64, uint64) internal burnNonces_
     )
@@ -120,7 +132,7 @@ contract DeployBase is ScriptBase {
     {
         (spokeRegistrar_, spokeMToken_) = _deploySpokeProtocol(deployer_, burnNonces_);
 
-        spokePortal_ = _deploySpokePortal(deployer_, spokeMToken_, spokeRegistrar_, wormholeChainId_);
+        spokePortal_ = _deploySpokePortal(deployer_, spokeMToken_, spokeRegistrar_, swapFacility_, wormholeChainId_);
         spokeTransceiver_ = _deployWormholeTransceiver(
             deployer_,
             transceiverConfig_,
@@ -164,10 +176,11 @@ contract DeployBase is ScriptBase {
     function _deployHubPortal(
         address deployer_,
         uint16 wormholeChainId_,
+        address swapFacility_,
         HubDeployConfig memory config_,
         string memory contractName_
     ) internal returns (address hubPortal_) {
-        HubPortal implementation_ = new HubPortal(config_.mToken, config_.registrar, wormholeChainId_);
+        HubPortal implementation_ = new HubPortal(config_.mToken, config_.registrar, swapFacility_, wormholeChainId_);
         HubPortal hubPortalProxy_ = HubPortal(
             _deployCreate3Proxy(address(implementation_), _computeSalt(deployer_, contractName_))
         );
@@ -181,9 +194,10 @@ contract DeployBase is ScriptBase {
         address deployer_,
         address mToken_,
         address registrar_,
+        address swapFacility_,
         uint16 wormholeChainId_
     ) internal returns (address pokePortal_) {
-        SpokePortal implementation_ = new SpokePortal(mToken_, registrar_, wormholeChainId_);
+        SpokePortal implementation_ = new SpokePortal(mToken_, registrar_, swapFacility_, wormholeChainId_);
         SpokePortal spokePortalProxy_ = SpokePortal(
             _deployCreate3Proxy(address(implementation_), _computeSalt(deployer_, _PORTAL_CONTRACT_NAME))
         );

--- a/script/deploy/DeployHub.s.sol
+++ b/script/deploy/DeployHub.s.sol
@@ -24,6 +24,7 @@ contract DeployHub is DeployBase {
         (address portal_, address transceiver_) = _deployHubComponents(
             deployer_,
             chainId_.toWormholeChainId(),
+            _SWAP_FACILITY,
             hubDeployConfig_,
             transceiverConfig_
         );

--- a/script/deploy/DeployNobleHub.s.sol
+++ b/script/deploy/DeployNobleHub.s.sol
@@ -31,6 +31,7 @@ contract DeployNobleHub is DeployBase {
         (address portal_, address transceiver_) = _deployNobleHubComponents(
             deployer_,
             chainId_.toWormholeChainId(),
+            _SWAP_FACILITY,
             hubDeployConfig_,
             transceiverConfig_
         );

--- a/script/deploy/DeploySpoke.s.sol
+++ b/script/deploy/DeploySpoke.s.sol
@@ -24,6 +24,7 @@ contract DeploySpoke is DeployBase {
         (address portal_, address transceiver_, address registrar_, address mToken_) = _deploySpokeComponents(
             deployer_,
             chainId_.toWormholeChainId(),
+            _SWAP_FACILITY,
             transceiverConfig_,
             _burnNonces
         );

--- a/script/upgrade/UpgradeBase.sol
+++ b/script/upgrade/UpgradeBase.sol
@@ -37,8 +37,14 @@ contract UpgradeBase is ScriptBase {
         ITransceiver(transceiver_).upgrade(address(implementation_));
     }
 
-    function _upgradeHubPortal(address portal_, address mToken_, address registrar_, uint16 wormholeChainId_) internal {
-        HubPortal implementation_ = new HubPortal(mToken_, registrar_, wormholeChainId_);
+    function _upgradeHubPortal(
+        address portal_,
+        address mToken_,
+        address registrar_,
+        address swapFacility_,
+        uint16 wormholeChainId_
+    ) internal {
+        HubPortal implementation_ = new HubPortal(mToken_, registrar_, swapFacility_, wormholeChainId_);
 
         console.log("HubPortal implementation deployed at: ", address(implementation_));
 
@@ -49,9 +55,10 @@ contract UpgradeBase is ScriptBase {
         address portal_,
         address mToken_,
         address registrar_,
+        address swapFacility_,
         uint16 wormholeChainId_
     ) internal {
-        SpokePortal implementation_ = new SpokePortal(mToken_, registrar_, wormholeChainId_);
+        SpokePortal implementation_ = new SpokePortal(mToken_, registrar_, swapFacility_, wormholeChainId_);
 
         console.log("SpokePortal implementation deployed at: ", address(implementation_));
 

--- a/script/upgrade/UpgradeHubPortal.s.sol
+++ b/script/upgrade/UpgradeHubPortal.s.sol
@@ -15,7 +15,7 @@ contract UpgradeHubPortal is UpgradeBase {
 
         vm.startBroadcast(deployer_);
 
-        _upgradeHubPortal(portal_, mToken_, registrar_, chainId_.toWormholeChainId());
+        _upgradeHubPortal(portal_, mToken_, registrar_, _SWAP_FACILITY, chainId_.toWormholeChainId());
 
         vm.stopBroadcast();
     }

--- a/script/upgrade/UpgradeSpokePortal.s.sol
+++ b/script/upgrade/UpgradeSpokePortal.s.sol
@@ -15,7 +15,7 @@ contract UpgradeSpokePortal is UpgradeBase {
 
         vm.startBroadcast(deployer_);
 
-        _upgradeSpokePortal(portal_, mToken_, registrar_, chainId_.toWormholeChainId());
+        _upgradeSpokePortal(portal_, mToken_, registrar_, _SWAP_FACILITY, chainId_.toWormholeChainId());
 
         vm.stopBroadcast();
     }

--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -36,15 +36,17 @@ contract HubPortal is IHubPortal, Portal {
 
     /**
      * @notice Constructs the contract.
-     * @param  mToken_    The address of the M token to bridge.
-     * @param  registrar_ The address of the Registrar.
-     * @param  chainId_   Wormhole chain id.
+     * @param  mToken_       The address of the M token to bridge.
+     * @param  registrar_    The address of the Registrar.
+     * @param  swapFacility_ The address of Swap Facility.
+     * @param  chainId_      Wormhole chain id.
      */
     constructor(
         address mToken_,
         address registrar_,
+        address swapFacility_,
         uint16 chainId_
-    ) Portal(mToken_, registrar_, Mode.LOCKING, chainId_) {}
+    ) Portal(mToken_, registrar_, swapFacility_, Mode.LOCKING, chainId_) {}
 
     /* ============ Interactive Functions ============ */
 

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -12,9 +12,7 @@ import {
 
 import { IPortal } from "./interfaces/IPortal.sol";
 import { ISwapFacilityLike } from "./interfaces/ISwapFacilityLike.sol";
-import { IWrappedMTokenLike } from "./interfaces/IWrappedMTokenLike.sol";
 import { TypeConverter } from "./libs/TypeConverter.sol";
-import { SafeCall } from "./libs/SafeCall.sol";
 import { PayloadType, PayloadEncoder } from "./libs/PayloadEncoder.sol";
 
 /**
@@ -25,7 +23,6 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
     using TypeConverter for *;
     using PayloadEncoder for bytes;
     using TrimmedAmountLib for *;
-    using SafeCall for address;
 
     uint16 internal constant _SOLANA_WORMHOLE_CHAIN_ID = 1;
     uint16 internal constant _FOGO_WORMHOLE_CHAIN_ID = 51;

--- a/src/SpokePortal.sol
+++ b/src/SpokePortal.sol
@@ -21,15 +21,17 @@ contract SpokePortal is ISpokePortal, Portal {
 
     /**
      * @notice Constructs the contract.
-     * @param  mToken_    The address of the M token to bridge.
-     * @param  registrar_ The address of the Registrar.
-     * @param  chainId_   Wormhole chain id.
+     * @param  mToken_       The address of the M token to bridge.
+     * @param  registrar_    The address of the Registrar.
+     * @param  swapFacility_ The address of Swap Facility.
+     * @param  chainId_      Wormhole chain id.
      */
     constructor(
         address mToken_,
         address registrar_,
+        address swapFacility_,
         uint16 chainId_
-    ) Portal(mToken_, registrar_, Mode.BURNING, chainId_) {}
+    ) Portal(mToken_, registrar_, swapFacility_, Mode.BURNING, chainId_) {}
 
     /* ============ Internal/Private Interactive Functions ============ */
 

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -88,6 +88,9 @@ interface IPortal {
     /// @notice Emitted when the Registrar address is 0x0.
     error ZeroRegistrar();
 
+    /// @notice Thrown when the Swap Facility address is 0x0.
+    error ZeroSwapFacility();
+
     /// @notice Emitted when the source token address is 0x0.
     error ZeroSourceToken();
 
@@ -115,6 +118,9 @@ interface IPortal {
 
     /// @notice The address of the Registrar contract.
     function registrar() external view returns (address);
+
+    /// @notice The address of the Swap Facility contract.
+    function swapFacility() external view returns (address swapFacility);
 
     /**
      * @notice Returns the address of M token on the destination chain.

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -122,6 +122,9 @@ interface IPortal {
     /// @notice The address of the Swap Facility contract.
     function swapFacility() external view returns (address);
 
+    /// @notice The address of the original caller of `transfer` and `transferMLikeToken` functions.
+    function msgSender() external view returns (address);
+
     /**
      * @notice Returns the address of M token on the destination chain.
      * @param  destinationChainId The Wormhole destination chain ID.

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -120,14 +120,14 @@ interface IPortal {
     function registrar() external view returns (address);
 
     /// @notice The address of the Swap Facility contract.
-    function swapFacility() external view returns (address swapFacility);
+    function swapFacility() external view returns (address);
 
     /**
      * @notice Returns the address of M token on the destination chain.
      * @param  destinationChainId The Wormhole destination chain ID.
      * @return mToken             The address of M token on the destination chain.
      */
-    function destinationMToken(uint16 destinationChainId) external view returns (bytes32 mToken);
+    function destinationMToken(uint16 destinationChainId) external view returns (bytes32);
 
     /**
      * @notice Indicates whether the provided bridging path is supported.

--- a/src/interfaces/ISwapFacilityLike.sol
+++ b/src/interfaces/ISwapFacilityLike.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.26;
+
+/**
+ * @title  Subset of SwapFacility interface.
+ * @author M0 Labs
+ */
+interface ISwapFacilityLike {
+    /**
+     * @notice Swaps $M token to $M Extension.
+     * @param  extensionOut The address of the M Extension to swap to.
+     * @param  amount       The amount of $M token to swap.
+     * @param  recipient    The address to receive the swapped $M Extension tokens.
+     */
+    function swapInM(address extensionOut, uint256 amount, address recipient) external;
+
+    /**
+     * @notice Swaps $M Extension to $M token.
+     * @param  extensionIn The address of the $M Extension to swap from.
+     * @param  amount      The amount of $M Extension tokens to swap.
+     * @param  recipient   The address to receive $M tokens.
+     */
+    function swapOutM(address extensionIn, uint256 amount, address recipient) external;
+}

--- a/test/fork/ForkTestBase.t.sol
+++ b/test/fork/ForkTestBase.t.sol
@@ -32,6 +32,7 @@ import { IPortal } from "../../src/interfaces/IPortal.sol";
 import { IMTokenLike } from "../../src/interfaces/IMTokenLike.sol";
 import { IHubPortal } from "../../src/interfaces/IHubPortal.sol";
 import { IRegistrarLike } from "../../src/interfaces/IRegistrarLike.sol";
+import { MockSwapFacility } from "../mocks/MockSwapFacility.sol";
 
 contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
     using WormholeConfig for uint256;
@@ -127,10 +128,12 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
 
         _hubWormholeCore = hubTransceiverConfig_.coreBridge;
         _hubGuardian = new WormholeSimulator(_hubWormholeCore, _DEVNET_GUARDIAN_PK);
+        address _swapFacility = address(new MockSwapFacility(address(_MAINNET_M_TOKEN)));
 
         (_hubPortal, _hubWormholeTransceiver) = _deployHubComponents(
             _DEPLOYER,
             ethereumWormholeChainId_,
+            _swapFacility,
             hubDeployConfig_,
             hubTransceiverConfig_
         );
@@ -174,13 +177,20 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
 
         _arbitrumSpokeWormholeCore = arbitrumSpokeTransceiverConfig_.coreBridge;
         _arbitrumSpokeGuardian = new WormholeSimulator(_arbitrumSpokeWormholeCore, _DEVNET_GUARDIAN_PK);
+        address _arbitrumSwapFacility = address(new MockSwapFacility(address(_MAINNET_M_TOKEN)));
 
         (
             _arbitrumSpokePortal,
             _arbitrumSpokeWormholeTransceiver,
             _arbitrumSpokeRegistrar,
             _arbitrumSpokeMToken
-        ) = _deploySpokeComponents(_DEPLOYER, arbitrumWormholeChainId_, arbitrumSpokeTransceiverConfig_, _burnNonces);
+        ) = _deploySpokeComponents(
+            _DEPLOYER,
+            arbitrumWormholeChainId_,
+            _arbitrumSwapFacility,
+            arbitrumSpokeTransceiverConfig_,
+            _burnNonces
+        );
 
         (, _arbitrumSpokeVault) = _deploySpokeVault(
             _DEPLOYER,
@@ -229,13 +239,20 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
 
         _optimismSpokeWormholeCore = optimismSpokeTransceiverConfig_.coreBridge;
         _optimismSpokeGuardian = new WormholeSimulator(_optimismSpokeWormholeCore, _DEVNET_GUARDIAN_PK);
+        address _optimismSwapFacility = address(new MockSwapFacility(address(_MAINNET_M_TOKEN)));
 
         (
             _optimismSpokePortal,
             _optimismSpokeWormholeTransceiver,
             _optimismSpokeRegistrar,
             _optimismSpokeMToken
-        ) = _deploySpokeComponents(_DEPLOYER, optimismWormholeChainId_, optimismSpokeTransceiverConfig_, _burnNonces);
+        ) = _deploySpokeComponents(
+            _DEPLOYER,
+            optimismWormholeChainId_,
+            _optimismSwapFacility,
+            optimismSpokeTransceiverConfig_,
+            _burnNonces
+        );
 
         (, _optimismSpokeVault) = _deploySpokeVault(
             _DEPLOYER,

--- a/test/fork/HubPortalFork.t.sol
+++ b/test/fork/HubPortalFork.t.sol
@@ -234,7 +234,7 @@ contract HubPortalForkTests is ForkTestBase {
             Chains.WORMHOLE_ARBITRUM
         );
 
-        assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_ - 1);
+        assertApproxEqAbs(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), amount_, 2);
 
         // Wormhole delivers message
         bytes memory signedMessage_ = _signMessage(_hubGuardian, Chains.WORMHOLE_ETHEREUM);
@@ -260,8 +260,8 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_
+            expectedHubBalance_: amount_ - 3,
+            expectedRecipientBalance_: amount_ - 3
         });
     }
 
@@ -277,8 +277,8 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_
+            expectedHubBalance_: amount_ - 3,
+            expectedRecipientBalance_: amount_ - 3
         });
     }
 
@@ -294,8 +294,8 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
+            expectedHubBalance_: amount_ - 3,
+            expectedRecipientBalance_: amount_ - 4
         });
     }
 
@@ -311,8 +311,8 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeMToken,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 2,
-            expectedRecipientBalance_: amount_ - 2
+            expectedHubBalance_: amount_ - 3,
+            expectedRecipientBalance_: amount_ - 4
         });
     }
 
@@ -328,7 +328,7 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 1,
+            expectedHubBalance_: amount_ - 2,
             expectedRecipientBalance_: amount_ - 1
         });
     }
@@ -345,7 +345,7 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 1,
+            expectedHubBalance_: amount_ - 2,
             expectedRecipientBalance_: amount_ - 1
         });
     }
@@ -362,7 +362,7 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 1,
+            expectedHubBalance_: amount_ - 2,
             expectedRecipientBalance_: amount_ - 1
         });
     }
@@ -379,7 +379,7 @@ contract HubPortalForkTests is ForkTestBase {
             sourceToken_: _MAINNET_WRAPPED_M_TOKEN,
             destinationToken_: _arbitrumSpokeWrappedMTokenProxy,
             amount_: amount_,
-            expectedHubBalance_: amount_ - 1,
+            expectedHubBalance_: amount_ - 2,
             expectedRecipientBalance_: amount_ - 1
         });
     }

--- a/test/fork/Migrate.t.sol
+++ b/test/fork/Migrate.t.sol
@@ -30,7 +30,7 @@ contract Migrate is ForkTestBase, UpgradeBase {
 
         vm.startPrank(_DEPLOYER);
 
-        _upgradeHubPortal(_hubPortal, _MAINNET_M_TOKEN, _MAINNET_REGISTRAR, Chains.WORMHOLE_ETHEREUM);
+        _upgradeHubPortal(_hubPortal, _MAINNET_M_TOKEN, _MAINNET_REGISTRAR, _SWAP_FACILITY, Chains.WORMHOLE_ETHEREUM);
 
         vm.stopPrank();
     }
@@ -44,6 +44,7 @@ contract Migrate is ForkTestBase, UpgradeBase {
             _arbitrumSpokePortal,
             _arbitrumSpokeMToken,
             _arbitrumSpokeRegistrar,
+            _SWAP_FACILITY,
             Chains.WORMHOLE_ARBITRUM
         );
 
@@ -53,7 +54,7 @@ contract Migrate is ForkTestBase, UpgradeBase {
     function testFork_migrate_wormholeTransceiver() external {
         vm.selectFork(_mainnetForkId);
 
-        assertEq(WormholeTransceiver(_hubWormholeTransceiver).gasLimit(), 300_000);
+        assertEq(WormholeTransceiver(_hubWormholeTransceiver).gasLimit(), 400_000);
 
         WormholeTransceiverConfig memory transceiverConfig_ = WormholeConfig.getWormholeTransceiverConfig(
             block.chainid

--- a/test/harnesses/PortalHarness.sol
+++ b/test/harnesses/PortalHarness.sol
@@ -8,7 +8,8 @@ contract PortalHarness is Portal {
     constructor(
         address mToken_,
         address registrar_,
+        address swapFacility_,
         Mode mode_,
         uint16 chainId_
-    ) Portal(mToken_, registrar_, mode_, chainId_) {}
+    ) Portal(mToken_, registrar_, swapFacility_, mode_, chainId_) {}
 }

--- a/test/integration/DeployHubPortal.t.sol
+++ b/test/integration/DeployHubPortal.t.sol
@@ -42,6 +42,7 @@ contract DeployHubPortalTests is Test, DeployBase {
         (address hubPortal_, ) = _deployHubComponents(
             _DEPLOYER,
             block.chainid.toWormholeChainId(),
+            _SWAP_FACILITY,
             hubDeployConfig_,
             hubTransceiverConfig_
         );

--- a/test/integration/DeployNobleHubPortal.t.sol
+++ b/test/integration/DeployNobleHubPortal.t.sol
@@ -37,6 +37,7 @@ contract DeployNobleHubPortalTests is Test, DeployBase {
         (address hubPortal_, address transceiver_) = _deployNobleHubComponents(
             _DEPLOYER,
             block.chainid.toWormholeChainId(),
+            _SWAP_FACILITY,
             hubDeployConfig_,
             hubTransceiverConfig_
         );

--- a/test/mocks/MockSwapFacility.sol
+++ b/test/mocks/MockSwapFacility.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
+
+interface IMExtension {
+    function wrap(address recipient, uint256 amount) external;
+    function unwrap(address recipient, uint256 amount) external;
+}
+
+contract MockSwapFacility {
+    address public immutable mToken;
+
+    constructor(address mToken_) {
+        mToken = mToken_;
+    }
+
+    function swapInM(address extensionOut, uint256 amount, address recipient) external {
+        IERC20(mToken).transferFrom(msg.sender, address(this), amount);
+        IERC20(mToken).approve(extensionOut, amount);
+        IMExtension(extensionOut).wrap(recipient, amount);
+    }
+
+    function swapOutM(address extensionIn, uint256 amount, address recipient) external {
+        IERC20(extensionIn).transferFrom(msg.sender, address(this), amount);
+
+        uint256 balanceBefore = IERC20(mToken).balanceOf(address(this));
+        IMExtension(extensionIn).unwrap(address(this), amount);
+
+        amount = IERC20(mToken).balanceOf(address(this)) - balanceBefore;
+        IERC20(mToken).transfer(recipient, amount);
+    }
+}

--- a/test/unit/HubExecutorEntryPoint.t.sol
+++ b/test/unit/HubExecutorEntryPoint.t.sol
@@ -7,7 +7,6 @@ import { TransceiverStructs } from "../../lib/native-token-transfers/evm/src/lib
 import { IPortal } from "../../src/interfaces/IPortal.sol";
 import { IHubPortal } from "../../src/interfaces/IHubPortal.sol";
 import { HubPortal } from "../../src/HubPortal.sol";
-import { PayloadEncoder } from "../../src/libs/PayloadEncoder.sol";
 import { TypeConverter } from "../../src/libs/TypeConverter.sol";
 import { ExecutorArgs } from "../../src/interfaces/IHubExecutorEntryPoint.sol";
 import { ExecutorMessages } from "../../src/external/ExecutorMessages.sol";
@@ -21,6 +20,7 @@ import { MockTransceiverPrice } from "../mocks/MockTransceiver.sol";
 import { MockMerkleTreeBuilder } from "../mocks/MockMerkleTreeBuilder.sol";
 import { MockExecutor } from "../mocks/MockExecutor.sol";
 import { MockWormhole } from "../mocks/MockWormhole.sol";
+import { MockSwapFacility } from "../mocks/MockSwapFacility.sol";
 
 contract HubExecutorEntryPointTest is UnitTestBase {
     using TypeConverter for *;
@@ -39,6 +39,7 @@ contract HubExecutorEntryPointTest is UnitTestBase {
     MockExecutor internal _executor;
     MockWormhole internal _wormhole;
     MockTransceiverPrice internal _transceiverWithPrice;
+    MockSwapFacility internal _swapFacility;
 
     HubPortal internal _portal;
     HubExecutorEntryPoint internal _executorEntryPoint;
@@ -72,8 +73,14 @@ contract HubExecutorEntryPointTest is UnitTestBase {
         _merkleTreeBuilder = new MockMerkleTreeBuilder();
         _executor = new MockExecutor();
         _wormhole = new MockWormhole(_LOCAL_CHAIN_ID);
+        _swapFacility = new MockSwapFacility(address(_mToken));
 
-        HubPortal portalImplementation_ = new HubPortal(address(_mToken), address(_registrar), _LOCAL_CHAIN_ID);
+        HubPortal portalImplementation_ = new HubPortal(
+            address(_mToken),
+            address(_registrar),
+            address(_swapFacility),
+            _LOCAL_CHAIN_ID
+        );
         _portal = HubPortal(_createProxy(address(portalImplementation_)));
 
         HubExecutorEntryPoint executorEntryPointImplementation_ = new HubExecutorEntryPoint(

--- a/test/unit/HubPortal.t.sol
+++ b/test/unit/HubPortal.t.sol
@@ -17,6 +17,7 @@ import { UnitTestBase } from "./UnitTestBase.t.sol";
 import { MockHubMToken } from "../mocks/MockHubMToken.sol";
 import { MockWrappedMToken } from "../mocks/MockWrappedMToken.sol";
 import { MockHubRegistrar } from "../mocks/MockHubRegistrar.sol";
+import { MockSwapFacility } from "../mocks/MockSwapFacility.sol";
 import { MockTransceiver } from "../mocks/MockTransceiver.sol";
 import { MockMerkleTreeBuilder } from "../mocks/MockMerkleTreeBuilder.sol";
 
@@ -34,6 +35,7 @@ contract HubPortalTests is UnitTestBase {
     bytes32 internal _remoteMToken;
     bytes32 internal _remoteWrappedMToken;
     MockHubRegistrar internal _registrar;
+    MockSwapFacility internal _swapFacility;
     MockMerkleTreeBuilder internal _merkleTreeBuilder;
 
     HubPortal internal _portal;
@@ -57,8 +59,14 @@ contract HubPortalTests is UnitTestBase {
         _registrar = new MockHubRegistrar();
         _transceiver = new MockTransceiver();
         _merkleTreeBuilder = new MockMerkleTreeBuilder();
+        _swapFacility = new MockSwapFacility(address(_mToken));
 
-        HubPortal implementation_ = new HubPortal(address(_mToken), address(_registrar), _LOCAL_CHAIN_ID);
+        HubPortal implementation_ = new HubPortal(
+            address(_mToken),
+            address(_registrar),
+            address(_swapFacility),
+            _LOCAL_CHAIN_ID
+        );
         _portal = HubPortal(_createProxy(address(implementation_)));
 
         _initializePortal(_portal);
@@ -78,6 +86,7 @@ contract HubPortalTests is UnitTestBase {
     function test_initialState() external view {
         assertEq(_portal.mToken(), address(_mToken));
         assertEq(_portal.registrar(), address(_registrar));
+        assertEq(_portal.swapFacility(), address(_swapFacility));
         assertEq(uint8(_portal.mode()), uint8(IManagerBase.Mode.LOCKING));
         assertEq(_portal.chainId(), _LOCAL_CHAIN_ID);
     }

--- a/test/unit/Portal.t.sol
+++ b/test/unit/Portal.t.sol
@@ -17,6 +17,7 @@ import { MockWrappedMToken } from "../mocks/MockWrappedMToken.sol";
 import { MockSpokeMToken } from "../mocks/MockSpokeMToken.sol";
 import { MockTransceiver } from "../mocks/MockTransceiver.sol";
 import { MockSpokeRegistrar } from "../mocks/MockSpokeRegistrar.sol";
+import { MockSwapFacility } from "../mocks/MockSwapFacility.sol";
 import { PortalHarness } from "../harnesses/PortalHarness.sol";
 
 contract PortalTests is UnitTestBase {
@@ -26,6 +27,7 @@ contract PortalTests is UnitTestBase {
     MockSpokeMToken internal _mToken;
     MockWrappedMToken internal _wrappedMToken;
     MockSpokeRegistrar internal _registrar;
+    MockSwapFacility internal _swapFacility;
     bytes32 internal _remoteMToken;
     bytes32 internal _remoteWrappedMToken;
 
@@ -41,11 +43,13 @@ contract PortalTests is UnitTestBase {
         _tokenAddress = address(_mToken);
 
         _registrar = new MockSpokeRegistrar();
+        _swapFacility = new MockSwapFacility(address(_mToken));
         _transceiver = new MockTransceiver();
 
         PortalHarness implementation_ = new PortalHarness(
             address(_mToken),
             address(_registrar),
+            address(_swapFacility),
             IManagerBase.Mode.BURNING,
             _LOCAL_CHAIN_ID
         );
@@ -61,12 +65,35 @@ contract PortalTests is UnitTestBase {
 
     function test_constructor_zeroMToken() external {
         vm.expectRevert(IPortal.ZeroMToken.selector);
-        new PortalHarness(address(0), address(_registrar), IManagerBase.Mode.BURNING, _LOCAL_CHAIN_ID);
+        new PortalHarness(
+            address(0),
+            address(_registrar),
+            address(_swapFacility),
+            IManagerBase.Mode.BURNING,
+            _LOCAL_CHAIN_ID
+        );
     }
 
     function test_constructor_zeroRegistrar() external {
         vm.expectRevert(IPortal.ZeroRegistrar.selector);
-        new PortalHarness(address(_mToken), address(0), IManagerBase.Mode.BURNING, _LOCAL_CHAIN_ID);
+        new PortalHarness(
+            address(_mToken),
+            address(0),
+            address(_swapFacility),
+            IManagerBase.Mode.BURNING,
+            _LOCAL_CHAIN_ID
+        );
+    }
+
+    function test_constructor_swapFacility() external {
+        vm.expectRevert(IPortal.ZeroSwapFacility.selector);
+        new PortalHarness(
+            address(_mToken),
+            address(_registrar),
+            address(0),
+            IManagerBase.Mode.BURNING,
+            _LOCAL_CHAIN_ID
+        );
     }
 
     /* ============ setDestinationMToken ============ */


### PR DESCRIPTION
### Proposed changes:
 - use `SwapFacility` to wrap and unwrap M Extensions in `Portal`
 
 ### Notes:
  - equivalent PR for Portal Lite was approved and already audited - https://github.com/m0-foundation/m-portal-lite/pull/31 
  - the actual changes in `Portal` contracts are really small, the majority of the changes are tests and scripts update
  - in fork tests some rounding values were updated, because with SwapFacility we added another transfer, not just wrap/unwrap - from `Portal` to `SwapFacility` and it results in additional rounding when transferring wrapped $M