### PR TITLE
feat: Upgrade Noble Portal to wrap/unwrap $M via SwapFacility [DO NOT MERGE]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,13 @@ deploy-noble-prod-eth: deploy-noble
 deploy-noble-dev-sepolia: RPC_URL=$(SEPOLIA_RPC_URL)
 deploy-noble-dev-sepolia: deploy-noble
 
+# Deploy Noble Hub Portal implementation for the SwapFacility upgrade.
+deploy-noble-upgrade-prod-eth: SCRIPT=script/upgrade/DeployNobleHubImplementation.s.sol:DeployNobleHubImplementation
+deploy-noble-upgrade-prod-eth: SIGNER_PRIVATE_KEY=$(PRIVATE_KEY)
+deploy-noble-upgrade-prod-eth: SCAN_API_KEY=$(ETHERSCAN_API_KEY)
+deploy-noble-upgrade-prod-eth: RPC_URL=$(MAINNET_RPC_URL)
+deploy-noble-upgrade-prod-eth: deploy
+
 # 
 # 
 # CONFIGURE

--- a/script/config/WormholeConfig.sol
+++ b/script/config/WormholeConfig.sol
@@ -20,7 +20,7 @@ library WormholeConfig {
     uint8 internal constant FINALIZED_CONSISTENCY_LEVEL = 1;
 
     /// @dev Gas limit to process a message on the destination
-    uint256 internal constant GAS_LIMIT = 300_000;
+    uint256 internal constant GAS_LIMIT = 400_000;
     address internal constant ZERO_ADDRESS = address(0);
 
     /// @dev Wormhole Chain Ids https://wormhole.com/docs/build/reference/chain-ids/

--- a/script/upgrade/DeployNobleHubImplementation.s.sol
+++ b/script/upgrade/DeployNobleHubImplementation.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { console } from "../../lib/forge-std/src/console.sol";
+import { Script } from "../../lib/forge-std/src/Script.sol";
+
+import {
+    IAccessControl
+} from "../../lib/native-token-transfers/evm/lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import { IManagerBase } from "../../lib/native-token-transfers/evm/src/interfaces/IManagerBase.sol";
+
+import { HubPortal } from "../../src/HubPortal.sol";
+
+/**
+ * @title  Deploys the new HubPortal implementation for the Noble Portal SwapFacility upgrade.
+ * @dev    The upgrade itself must be executed by the Noble Portal owner Safe,
+ *         and the M_SWAPPER_ROLE grant by the SwapFacility admin Safe.
+ *         This script only deploys the implementation and prints the required Safe transactions.
+ */
+contract DeployNobleHubImplementation is Script {
+    address internal constant _MAINNET_M_TOKEN = 0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b;
+    address internal constant _MAINNET_REGISTRAR = 0x119FbeeDD4F4f4298Fb59B720d5654442b81ae2c;
+    address internal constant _SWAP_FACILITY = 0xB6807116b3B1B321a390594e31ECD6e0076f6278;
+
+    address internal constant _NOBLE_PORTAL = 0x83Ae82Bd4054e815fB7B189C39D9CE670369ea16;
+    address internal constant _NOBLE_PORTAL_OWNER = 0x7176665e336e8692e9b265aB6290934C93F99cCf;
+    address internal constant _SWAP_FACILITY_ADMIN = 0x48670B46380FE1645f0E3e821a25162dB2589D19;
+
+    uint16 internal constant _ETHEREUM_WORMHOLE_CHAIN_ID = 2;
+
+    bytes32 internal constant _M_SWAPPER_ROLE = keccak256("M_SWAPPER_ROLE");
+
+    function run() external {
+        address deployer_ = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+
+        require(block.chainid == 1, "Mainnet only");
+
+        vm.startBroadcast(deployer_);
+
+        HubPortal implementation_ = new HubPortal(_MAINNET_M_TOKEN, _MAINNET_REGISTRAR, _ETHEREUM_WORMHOLE_CHAIN_ID);
+
+        vm.stopBroadcast();
+
+        console.log("Deployer:                  ", deployer_);
+        console.log("HubPortal implementation:  ", address(implementation_));
+    }
+}

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -10,9 +10,8 @@ import {
 } from "../lib/native-token-transfers/evm/src/NttManager/NttManagerNoRateLimiting.sol";
 
 import { IPortal } from "./interfaces/IPortal.sol";
-import { IWrappedMTokenLike } from "./interfaces/IWrappedMTokenLike.sol";
+import { ISwapFacilityLike } from "./interfaces/ISwapFacilityLike.sol";
 import { TypeConverter } from "./libs/TypeConverter.sol";
-import { SafeCall } from "./libs/SafeCall.sol";
 import { PayloadType, PayloadEncoder } from "./libs/PayloadEncoder.sol";
 
 /**
@@ -23,10 +22,13 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
     using TypeConverter for *;
     using PayloadEncoder for bytes;
     using TrimmedAmountLib for *;
-    using SafeCall for address;
 
     /// @dev Use only standard WormholeTransceiver with relaying enabled
     bytes public constant DEFAULT_TRANSCEIVER_INSTRUCTIONS = new bytes(1);
+
+    /// @notice The address of SwapFacility, the only contract allowed to wrap $M into $M extensions.
+    /// @dev    Hardcoded as a constant to avoid constructor and storage changes in this minimal upgrade.
+    address public constant SWAP_FACILITY = 0xB6807116b3B1B321a390594e31ECD6e0076f6278;
 
     /// @inheritdoc IPortal
     address public immutable registrar;
@@ -177,9 +179,10 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
         // transfer source token from the sender
         IERC20(sourceToken_).transferFrom(msg.sender, address(this), amount_);
 
-        // if the source token isn't M token, unwrap it
+        // if the source token isn't M token, unwrap it via SwapFacility
         if (sourceToken_ != address(mToken_)) {
-            IWrappedMTokenLike(sourceToken_).unwrap(address(this), amount_);
+            IERC20(sourceToken_).approve(SWAP_FACILITY, amount_);
+            ISwapFacilityLike(SWAP_FACILITY).swapOutM(sourceToken_, amount_, address(this));
         }
 
         // account for potential rounding errors when transferring between earners and non-earners
@@ -406,20 +409,20 @@ abstract contract Portal is NttManagerNoRateLimiting, IPortal {
      * @param amount_                  The amount to wrap.
      */
     function _wrap(address mToken_, address destinationWrappedToken_, address recipient_, uint256 amount_) private {
-        IERC20(mToken_).approve(destinationWrappedToken_, amount_);
+        IERC20(mToken_).approve(SWAP_FACILITY, amount_);
 
-        // Attempt to wrap $M token
+        // Attempt to wrap $M token via SwapFacility
         // NOTE: the call might fail with out-of-gas exception
         //       even if the destination token is the valid wrapped M token.
         //       Recipients must support both $M and wrapped $M transfers.
-        bool success = destinationWrappedToken_.safeCall(
-            abi.encodeCall(IWrappedMTokenLike.wrap, (recipient_, amount_))
+        (bool success, ) = SWAP_FACILITY.call(
+            abi.encodeCall(ISwapFacilityLike.swapInM, (destinationWrappedToken_, amount_, recipient_))
         );
 
         if (!success) {
             emit WrapFailed(destinationWrappedToken_, recipient_, amount_);
             // reset approval to prevent a potential double-spend attack
-            IERC20(mToken_).approve(destinationWrappedToken_, 0);
+            IERC20(mToken_).approve(SWAP_FACILITY, 0);
             // transfer $M token to the recipient
             IERC20(mToken_).transfer(recipient_, amount_);
         }

--- a/src/interfaces/ISwapFacilityLike.sol
+++ b/src/interfaces/ISwapFacilityLike.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.26;
+
+/**
+ * @title  Subset of SwapFacility interface.
+ * @author M0 Labs
+ */
+interface ISwapFacilityLike {
+    /**
+     * @notice Swaps $M token to $M Extension.
+     * @param  extensionOut The address of the M Extension to swap to.
+     * @param  amount       The amount of $M token to swap.
+     * @param  recipient    The address to receive the swapped $M Extension tokens.
+     */
+    function swapInM(address extensionOut, uint256 amount, address recipient) external;
+
+    /**
+     * @notice Swaps $M Extension to $M token.
+     * @param  extensionIn The address of the $M Extension to swap from.
+     * @param  amount      The amount of $M Extension tokens to swap.
+     * @param  recipient   The address to receive $M tokens.
+     */
+    function swapOutM(address extensionIn, uint256 amount, address recipient) external;
+}

--- a/test/fork/ForkTestBase.t.sol
+++ b/test/fork/ForkTestBase.t.sol
@@ -26,6 +26,9 @@ import { PeersConfig, PeerConfig } from "../../script/config/PeersConfig.sol";
 import { TypeConverter } from "../../src/libs/TypeConverter.sol";
 import { IHubPortal } from "../../src/interfaces/IHubPortal.sol";
 import { IRegistrarLike } from "../../src/interfaces/IRegistrarLike.sol";
+import { Portal } from "../../src/Portal.sol";
+
+import { MockSwapFacility } from "../mocks/MockSwapFacility.sol";
 
 contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
     using WormholeConfig for uint256;
@@ -72,6 +75,9 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
     uint256 internal _optimismForkId;
     uint256[] internal _forkIds = new uint256[](3);
 
+    /// @dev MockSwapFacility runtime code to set at the SwapFacility address on every fork.
+    bytes internal _mockSwapFacilityCode;
+
     // Mainnet - Hub
     address internal _hubPortal;
     address internal _hubWormholeTransceiver;
@@ -110,6 +116,11 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
         deal(_alice, 10 ether);
         deal(_mHolder, 10 ether);
 
+        // SwapFacility doesn't exist at the pinned fork blocks, deploy the mock
+        // to set its code at the SwapFacility address on every fork.
+        // NOTE: deployed before pranking `_DEPLOYER` to keep its nonce untouched.
+        _mockSwapFacilityCode = address(new MockSwapFacility()).code;
+
         vm.startPrank(_DEPLOYER);
 
         uint256 ethereumChainId_ = block.chainid;
@@ -128,6 +139,8 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
             hubDeployConfig_,
             hubTransceiverConfig_
         );
+
+        _mockSwapFacility(_hubPortal, _MAINNET_M_TOKEN);
 
         // set peers
         _configurePeers(
@@ -175,6 +188,8 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
             _arbitrumSpokeRegistrar,
             _arbitrumSpokeMToken
         ) = _deploySpokeComponents(_DEPLOYER, arbitrumWormholeChainId_, arbitrumSpokeTransceiverConfig_, _burnNonces);
+
+        _mockSwapFacility(_arbitrumSpokePortal, _arbitrumSpokeMToken);
 
         (, _arbitrumSpokeVault) = _deploySpokeVault(
             _DEPLOYER,
@@ -231,6 +246,8 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
             _optimismSpokeMToken
         ) = _deploySpokeComponents(_DEPLOYER, optimismWormholeChainId_, optimismSpokeTransceiverConfig_, _burnNonces);
 
+        _mockSwapFacility(_optimismSpokePortal, _optimismSpokeMToken);
+
         (, _optimismSpokeVault) = _deploySpokeVault(
             _DEPLOYER,
             _optimismSpokePortal,
@@ -258,6 +275,13 @@ contract ForkTestBase is TaskBase, ConfigureBase, DeployBase, Test {
         );
 
         vm.stopPrank();
+    }
+
+    /// @dev Deploys MockSwapFacility code at the SwapFacility address hardcoded in Portal.
+    function _mockSwapFacility(address portal_, address mToken_) internal {
+        address swapFacility_ = Portal(portal_).SWAP_FACILITY();
+        vm.etch(swapFacility_, _mockSwapFacilityCode);
+        MockSwapFacility(swapFacility_).setMToken(mToken_);
     }
 
     function _burnNonces(address account_, uint64 /**  startingNonce_ */, uint64 targetNonce_) internal {

--- a/test/fork/Migrate.t.sol
+++ b/test/fork/Migrate.t.sol
@@ -53,7 +53,7 @@ contract Migrate is ForkTestBase, UpgradeBase {
     function testFork_migrate_wormholeTransceiver() external {
         vm.selectFork(_mainnetForkId);
 
-        assertEq(WormholeTransceiver(_hubWormholeTransceiver).gasLimit(), 300_000);
+        assertEq(WormholeTransceiver(_hubWormholeTransceiver).gasLimit(), 400_000);
 
         WormholeTransceiverConfig memory transceiverConfig_ = WormholeConfig.getWormholeTransceiverConfig(
             block.chainid

--- a/test/fork/NobleUpgradeFork.t.sol
+++ b/test/fork/NobleUpgradeFork.t.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { Test } from "../../lib/forge-std/src/Test.sol";
+
+import {
+    IAccessControl
+} from "../../lib/native-token-transfers/evm/lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import { IManagerBase } from "../../lib/native-token-transfers/evm/src/interfaces/IManagerBase.sol";
+import { INttManager } from "../../lib/native-token-transfers/evm/src/interfaces/INttManager.sol";
+import { TrimmedAmountLib } from "../../lib/native-token-transfers/evm/src/libraries/TrimmedAmount.sol";
+import { TransceiverStructs } from "../../lib/native-token-transfers/evm/src/libraries/TransceiverStructs.sol";
+
+import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
+
+import { HubPortal } from "../../src/HubPortal.sol";
+import { IPortal } from "../../src/interfaces/IPortal.sol";
+import { ISwapFacilityLike } from "../../src/interfaces/ISwapFacilityLike.sol";
+import { PayloadEncoder } from "../../src/libs/PayloadEncoder.sol";
+import { TypeConverter } from "../../src/libs/TypeConverter.sol";
+
+/**
+ * @title  Mainnet fork tests for the Noble Portal SwapFacility upgrade.
+ * @dev    Simulates the real upgrade: deploys the new HubPortal implementation,
+ *         upgrades the Noble Portal proxy from its owner Safe, grants M_SWAPPER_ROLE
+ *         on the real SwapFacility, then exercises both bridging directions.
+ */
+contract NobleUpgradeForkTests is Test {
+    using TypeConverter for *;
+    using TrimmedAmountLib for *;
+
+    uint256 internal constant _MAINNET_FORK_BLOCK = 25_727_900;
+
+    address internal constant _M_TOKEN = 0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b;
+    address internal constant _WRAPPED_M_TOKEN = 0x437cc33344a0B27A429f795ff6B469C72698B291;
+    address internal constant _REGISTRAR = 0x119FbeeDD4F4f4298Fb59B720d5654442b81ae2c;
+    address internal constant _SWAP_FACILITY = 0xB6807116b3B1B321a390594e31ECD6e0076f6278;
+    address internal constant _SWAP_FACILITY_ADMIN = 0x48670B46380FE1645f0E3e821a25162dB2589D19;
+
+    address internal constant _NOBLE_PORTAL = 0x83Ae82Bd4054e815fB7B189C39D9CE670369ea16;
+    address internal constant _NOBLE_TRANSCEIVER = 0xc7Dd372c39E38BF11451ab4A8427B4Ae38ceF644;
+    address internal constant _NOBLE_PORTAL_OWNER = 0x7176665e336e8692e9b265aB6290934C93F99cCf;
+
+    uint16 internal constant _ETHEREUM_WORMHOLE_CHAIN_ID = 2;
+    uint16 internal constant _NOBLE_WORMHOLE_CHAIN_ID = 4009;
+
+    /// @dev Noble Portal peer on Noble chain, `getPeer(4009)` of the live Noble Portal.
+    bytes32 internal constant _NOBLE_PEER = 0x0000000000000000000000002e859506ba229c183f8985d54fe7210923fb9bca;
+
+    /// @dev $M token denom on Noble ("uusdn"), `destinationMToken(4009)` of the live Noble Portal.
+    bytes32 internal constant _NOBLE_M_TOKEN = 0x000000000000000000000000000000000000000000000000000000757573646e;
+
+    bytes32 internal constant _M_SWAPPER_ROLE = keccak256("M_SWAPPER_ROLE");
+
+    address internal immutable _alice = makeAddr("alice");
+
+    function setUp() external {
+        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), _MAINNET_FORK_BLOCK);
+
+        // Deploy the new implementation with the same immutables as the live one
+        HubPortal implementation_ = new HubPortal(_M_TOKEN, _REGISTRAR, _ETHEREUM_WORMHOLE_CHAIN_ID);
+
+        // Upgrade the Noble Portal proxy from its owner Safe
+        vm.prank(_NOBLE_PORTAL_OWNER);
+        IManagerBase(_NOBLE_PORTAL).upgrade(address(implementation_));
+
+        // Grant M_SWAPPER_ROLE to the Noble Portal on SwapFacility
+        vm.prank(_SWAP_FACILITY_ADMIN);
+        IAccessControl(_SWAP_FACILITY).grantRole(_M_SWAPPER_ROLE, _NOBLE_PORTAL);
+    }
+
+    /* ============ upgrade ============ */
+
+    function testFork_upgrade_state() external view {
+        assertEq(HubPortal(_NOBLE_PORTAL).SWAP_FACILITY(), _SWAP_FACILITY);
+        assertEq(HubPortal(_NOBLE_PORTAL).registrar(), _REGISTRAR);
+        assertEq(INttManager(_NOBLE_PORTAL).token(), _M_TOKEN);
+        assertEq(HubPortal(_NOBLE_PORTAL).destinationMToken(_NOBLE_WORMHOLE_CHAIN_ID), _NOBLE_M_TOKEN);
+        assertTrue(
+            HubPortal(_NOBLE_PORTAL).supportedBridgingPath(_WRAPPED_M_TOKEN, _NOBLE_WORMHOLE_CHAIN_ID, _NOBLE_M_TOKEN)
+        );
+    }
+
+    /* ============ receive from Noble ============ */
+
+    function testFork_receiveMToken() external {
+        uint256 amount_ = 1_000e6;
+        uint256 balanceBefore_ = IERC20(_M_TOKEN).balanceOf(_alice);
+
+        _receiveFromNoble(amount_, _M_TOKEN.toBytes32(), _alice.toBytes32());
+
+        assertApproxEqAbs(IERC20(_M_TOKEN).balanceOf(_alice) - balanceBefore_, amount_, 2);
+    }
+
+    function testFork_receiveWrappedMToken_wrapsViaSwapFacility() external {
+        uint256 amount_ = 1_000e6;
+
+        assertEq(IERC20(_WRAPPED_M_TOKEN).balanceOf(_alice), 0);
+
+        // Expect the Portal to wrap via SwapFacility
+        vm.expectCall(_SWAP_FACILITY, abi.encodeCall(ISwapFacilityLike.swapInM, (_WRAPPED_M_TOKEN, amount_, _alice)));
+
+        _receiveFromNoble(amount_, _WRAPPED_M_TOKEN.toBytes32(), _alice.toBytes32());
+
+        assertApproxEqAbs(IERC20(_WRAPPED_M_TOKEN).balanceOf(_alice), amount_, 2);
+        assertEq(IERC20(_M_TOKEN).balanceOf(_alice), 0);
+    }
+
+    function testFork_receiveWrappedMToken_invalidWrappedToken_fallsBackToMToken() external {
+        uint256 amount_ = 1_000e6;
+        address invalidToken_ = makeAddr("invalid");
+
+        // SwapFacility reverts for a non-approved extension, the Portal transfers $M instead
+        _receiveFromNoble(amount_, invalidToken_.toBytes32(), _alice.toBytes32());
+
+        assertApproxEqAbs(IERC20(_M_TOKEN).balanceOf(_alice), amount_, 2);
+    }
+
+    /* ============ send to Noble ============ */
+
+    function testFork_transferMToken() external {
+        uint256 amount_ = 1_000e6;
+        uint256 portalBalanceBefore_ = IERC20(_M_TOKEN).balanceOf(_NOBLE_PORTAL);
+
+        _fundAliceWithMToken(amount_);
+
+        vm.startPrank(_alice);
+        IERC20(_M_TOKEN).approve(_NOBLE_PORTAL, amount_);
+        IPortal(_NOBLE_PORTAL).transferMLikeToken(
+            amount_,
+            _M_TOKEN,
+            _NOBLE_WORMHOLE_CHAIN_ID,
+            _NOBLE_M_TOKEN,
+            _alice.toBytes32(),
+            _alice.toBytes32()
+        );
+        vm.stopPrank();
+
+        assertApproxEqAbs(IERC20(_M_TOKEN).balanceOf(_NOBLE_PORTAL) - portalBalanceBefore_, amount_, 2);
+        assertEq(IERC20(_M_TOKEN).balanceOf(_alice), 0);
+    }
+
+    function testFork_transferWrappedMToken_unwrapsViaSwapFacility() external {
+        uint256 amount_ = 1_000e6;
+        uint256 portalBalanceBefore_ = IERC20(_M_TOKEN).balanceOf(_NOBLE_PORTAL);
+
+        _fundAliceWithWrappedMToken(amount_);
+        amount_ = IERC20(_WRAPPED_M_TOKEN).balanceOf(_alice);
+
+        // Expect the Portal to unwrap via SwapFacility
+        vm.expectCall(
+            _SWAP_FACILITY,
+            abi.encodeCall(ISwapFacilityLike.swapOutM, (_WRAPPED_M_TOKEN, amount_, _NOBLE_PORTAL))
+        );
+
+        vm.startPrank(_alice);
+        IERC20(_WRAPPED_M_TOKEN).approve(_NOBLE_PORTAL, amount_);
+        IPortal(_NOBLE_PORTAL).transferMLikeToken(
+            amount_,
+            _WRAPPED_M_TOKEN,
+            _NOBLE_WORMHOLE_CHAIN_ID,
+            _NOBLE_M_TOKEN,
+            _alice.toBytes32(),
+            _alice.toBytes32()
+        );
+        vm.stopPrank();
+
+        assertApproxEqAbs(IERC20(_M_TOKEN).balanceOf(_NOBLE_PORTAL) - portalBalanceBefore_, amount_, 2);
+        assertEq(IERC20(_WRAPPED_M_TOKEN).balanceOf(_alice), 0);
+    }
+
+    /* ============ helpers ============ */
+
+    /// @dev Delivers a token transfer message from Noble by pranking the Noble Wormhole transceiver.
+    function _receiveFromNoble(uint256 amount_, bytes32 destinationToken_, bytes32 recipient_) internal {
+        uint8 decimals_ = IERC20(_M_TOKEN).decimals();
+
+        TransceiverStructs.NativeTokenTransfer memory nativeTokenTransfer_ = TransceiverStructs.NativeTokenTransfer(
+            amount_.trim(decimals_, decimals_),
+            _NOBLE_M_TOKEN,
+            recipient_,
+            _ETHEREUM_WORMHOLE_CHAIN_ID,
+            PayloadEncoder.encodeAdditionalPayload(0, destinationToken_)
+        );
+
+        TransceiverStructs.NttManagerMessage memory message_ = TransceiverStructs.NttManagerMessage(
+            bytes32(uint256(1)),
+            recipient_,
+            TransceiverStructs.encodeNativeTokenTransfer(nativeTokenTransfer_)
+        );
+
+        vm.prank(_NOBLE_TRANSCEIVER);
+        INttManager(_NOBLE_PORTAL).attestationReceived(_NOBLE_WORMHOLE_CHAIN_ID, _NOBLE_PEER, message_);
+    }
+
+    /// @dev Funds `_alice` with $M token from the Wrapped M contract's backing balance.
+    function _fundAliceWithMToken(uint256 amount_) internal {
+        vm.prank(_WRAPPED_M_TOKEN);
+        IERC20(_M_TOKEN).transfer(_alice, amount_);
+    }
+
+    /// @dev Funds `_alice` with Wrapped M by swapping $M via the real SwapFacility.
+    function _fundAliceWithWrappedMToken(uint256 amount_) internal {
+        _fundAliceWithMToken(amount_);
+
+        vm.prank(_SWAP_FACILITY_ADMIN);
+        IAccessControl(_SWAP_FACILITY).grantRole(_M_SWAPPER_ROLE, _alice);
+
+        vm.startPrank(_alice);
+        IERC20(_M_TOKEN).approve(_SWAP_FACILITY, amount_);
+        ISwapFacilityLike(_SWAP_FACILITY).swapInM(_WRAPPED_M_TOKEN, amount_, _alice);
+        vm.stopPrank();
+    }
+}

--- a/test/fork/SpokePortalFork.t.sol
+++ b/test/fork/SpokePortalFork.t.sol
@@ -164,7 +164,10 @@ contract SpokePortalForkTests is ForkTestBase {
         _deliverMessage(_MAINNET_WORMHOLE_RELAYER, signedMessage_);
 
         assertEq(IERC20(_MAINNET_M_TOKEN).balanceOf(_hubPortal), 0);
-        assertEq(IERC20(destinationToken_).balanceOf(user_), balanceOfBefore_ + _amount);
+
+        // Wrapping via SwapFacility adds an extra $M transfer hop, losing 1 wei to earner rounding
+        uint256 expectedAmount_ = destinationToken_ == _MAINNET_WRAPPED_M_TOKEN ? _amount - 1 : _amount;
+        assertEq(IERC20(destinationToken_).balanceOf(user_), balanceOfBefore_ + expectedAmount_);
     }
 
     function _beforeTest() internal {

--- a/test/mocks/MockSwapFacility.sol
+++ b/test/mocks/MockSwapFacility.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
+
+import { MockWrappedMToken } from "./MockWrappedMToken.sol";
+
+contract MockSwapFacility {
+    address public mToken;
+
+    function setMToken(address mToken_) external {
+        mToken = mToken_;
+    }
+
+    function swapInM(address extensionOut_, uint256 amount_, address recipient_) external {
+        IERC20(mToken).transferFrom(msg.sender, address(this), amount_);
+        IERC20(mToken).approve(extensionOut_, amount_);
+        MockWrappedMToken(extensionOut_).wrap(recipient_, amount_);
+    }
+
+    function swapOutM(address extensionIn_, uint256 amount_, address recipient_) external {
+        IERC20(extensionIn_).transferFrom(msg.sender, address(this), amount_);
+        MockWrappedMToken(extensionIn_).unwrap(recipient_, amount_);
+    }
+}

--- a/test/unit/HubPortal.t.sol
+++ b/test/unit/HubPortal.t.sol
@@ -43,6 +43,7 @@ contract HubPortalTests is UnitTestBase {
 
         HubPortal implementation_ = new HubPortal(address(_mToken), address(_registrar), _LOCAL_CHAIN_ID);
         _portal = HubPortal(_createProxy(address(implementation_)));
+        _mockSwapFacility(_portal, address(_mToken));
 
         _initializePortal(_portal);
         _portal.setDestinationMToken(_REMOTE_CHAIN_ID, _remoteMToken);

--- a/test/unit/Portal.t.sol
+++ b/test/unit/Portal.t.sol
@@ -50,6 +50,7 @@ contract PortalTests is UnitTestBase {
             _LOCAL_CHAIN_ID
         );
         _portal = PortalHarness(_createProxy(address(implementation_)));
+        _mockSwapFacility(_portal, address(_mToken));
         _initializePortal(_portal);
         _portal.setDestinationMToken(_REMOTE_CHAIN_ID, _remoteMToken);
         _portal.setSupportedBridgingPath(address(_mToken), _REMOTE_CHAIN_ID, _remoteMToken, true);

--- a/test/unit/SpokePortal.t.sol
+++ b/test/unit/SpokePortal.t.sol
@@ -43,6 +43,7 @@ contract SpokePortalTests is UnitTestBase {
 
         SpokePortal implementation_ = new SpokePortal(address(_mToken), address(_registrar), _LOCAL_CHAIN_ID);
         _portal = SpokePortal(_createProxy(address(implementation_)));
+        _mockSwapFacility(_portal, address(_mToken));
 
         _initializePortal(_portal);
 

--- a/test/unit/UnitTestBase.t.sol
+++ b/test/unit/UnitTestBase.t.sol
@@ -14,6 +14,7 @@ import { TypeConverter } from "../../src/libs/TypeConverter.sol";
 import { PayloadEncoder } from "../../src/libs/PayloadEncoder.sol";
 import { Portal } from "../../src/Portal.sol";
 
+import { MockSwapFacility } from "../mocks/MockSwapFacility.sol";
 import { MockTransceiver } from "../mocks/MockTransceiver.sol";
 
 contract UnitTestBase is Test {
@@ -51,6 +52,13 @@ contract UnitTestBase is Test {
 
     function _createProxy(address implementation_) internal returns (address proxy_) {
         return address(new ERC1967Proxy(implementation_, ""));
+    }
+
+    /// @dev Deploys MockSwapFacility code at the SwapFacility address hardcoded in Portal.
+    function _mockSwapFacility(Portal portal_, address mToken_) internal {
+        address swapFacility_ = portal_.SWAP_FACILITY();
+        vm.etch(swapFacility_, address(new MockSwapFacility()).code);
+        MockSwapFacility(swapFacility_).setMToken(mToken_);
     }
 
     function _initializePortal(Portal portal_) internal {


### PR DESCRIPTION
### Description
Minimal patch on top of v1.0.0 (the release the live Noble Portal was deployed from) to support the Wrapped M v2, where wrap/unwrap are restricted to `SwapFacility`.

### Changes
- `Portal._wrap`: wraps M via `SwapFacility.swapInM` instead of calling wrap on the destination token directly. Failure fallback is unchanged: deliver plain $M to the recipient and emit `WrapFailed`.
- `Portal._transferMLikeToken`: unwraps the source wrapped token via `SwapFacility.swapOutM` instead of `unwrap`.
- `SWAP_FACILITY` is hardcoded as a public constant — no constructor or storage changes.
- Added `ISwapFacilityLike` interface

### Testing
New mainnet fork tests (`test/fork/NobleUpgradeFork.t.sol`) simulate the full upgrade and bridging in both directions against the real `SwapFacility` and `wM`.